### PR TITLE
Implement config loader, event bus, and savegame persistence

### DIFF
--- a/100_schritte_plan.md
+++ b/100_schritte_plan.md
@@ -18,9 +18,9 @@
 8. [x] **GameState-Gerüst:** `state.py` (immutable Snapshots) + einfache Serialisierung.
 9. [x] **Tick-Loop & CLI:** `ki-sim run --ticks` implementieren; Smoke-Test mit Seed=42 grün.
 10. [x] **Logging-Basis:** Strukturierte Logs (Tick, Duration, Seed); Silence-Levels konfigurierbar.
-11. [ ] **Config-Lader:** YAML/TOML-Loader + Pydantic-Schemas; ein Beispiel-Profil `default` bereitstellen.
-12. [ ] **Ereignisbus (EventBus):** Publish/Subscribe-Grundgerüst; leere Events für spätere Systeme.
-13. [ ] **Persistenz-Roundtrip:** `savegame.py` (JSON) + Test `state == load(save(state))`.
+11. [x] **Config-Lader:** YAML/TOML-Loader + Pydantic-Schemas; ein Beispiel-Profil `default` bereitstellen.
+12. [x] **Ereignisbus (EventBus):** Publish/Subscribe-Grundgerüst; leere Events für spätere Systeme.
+13. [x] **Persistenz-Roundtrip:** `savegame.py` (JSON) + Test `state == load(save(state))`.
 14. [ ] **Benchmark-Skeleton:** pytest-benchmark setuppen; Basis-Messung für Tick-Loop einfrieren.
 15. [ ] **Client-Projekt initialisieren:** Leere Szenen/Scenes (Dashboard-Mock), Build-Pipeline lauffähig.
 16. [ ] **API-Adapter (optional):** FastAPI-Stub mit `/state` (GET) → Client liest Dummy-State.

--- a/sim/config/profiles/default.yaml
+++ b/sim/config/profiles/default.yaml
@@ -1,0 +1,8 @@
+name: default
+description: Baseline balancing profile for smoke tests.
+ticks: 30
+seed: 42
+economy:
+  daily_active_users: 5000
+  arp_dau: 0.12
+  operating_costs: 450.0

--- a/sim/poetry.lock
+++ b/sim/poetry.lock
@@ -609,7 +609,7 @@ version = "6.0.3"
 description = "YAML parser and emitter for Python"
 optional = false
 python-versions = ">=3.8"
-groups = ["dev"]
+groups = ["main", "dev"]
 files = [
     {file = "PyYAML-6.0.3-cp38-cp38-macosx_10_13_x86_64.whl", hash = "sha256:c2514fceb77bc5e7a2f7adfaa1feb2fb311607c9cb518dbc378688ec73d8292f"},
     {file = "PyYAML-6.0.3-cp38-cp38-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9c57bb8c96f6d1808c030b1687b9b5fb476abaa47f0db9c0101f5e9f394e97f4"},
@@ -810,4 +810,4 @@ test = ["covdefaults (>=2.3)", "coverage (>=7.2.7)", "coverage-enable-subprocess
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.11"
-content-hash = "9a10d1973d4774c08ec82317fcd89a1fced206f16f36920c2f3bd97eb12d54e6"
+content-hash = "fa8e63b9e5fa038aff4afb72f661d19e4e8575bc3fa0302d77c2324636960178"

--- a/sim/pyproject.toml
+++ b/sim/pyproject.toml
@@ -10,6 +10,7 @@ packages = [{ include = "ki_dev_tycoon", from = "src" }]
 [tool.poetry.dependencies]
 python = "^3.11"
 pydantic = "^2.9.0"
+pyyaml = "^6.0.2"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^8.3.3"

--- a/sim/src/ki_dev_tycoon/config/__init__.py
+++ b/sim/src/ki_dev_tycoon/config/__init__.py
@@ -1,0 +1,14 @@
+"""Configuration loading helpers for KI Dev Tycoon."""
+
+from __future__ import annotations
+
+from .loader import ConfigLoader, ConfigLoaderError, load_profile
+from .schemas import EconomyConfig, SimulationProfile
+
+__all__ = [
+    "ConfigLoader",
+    "EconomyConfig",
+    "ConfigLoaderError",
+    "SimulationProfile",
+    "load_profile",
+]

--- a/sim/src/ki_dev_tycoon/config/loader.py
+++ b/sim/src/ki_dev_tycoon/config/loader.py
@@ -1,0 +1,85 @@
+"""Utilities for loading simulation configuration files."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Iterable
+
+import tomllib
+import yaml
+from pydantic import ValidationError
+
+from .schemas import SimulationProfile
+
+SUPPORTED_SUFFIXES: tuple[str, ...] = (".yaml", ".yml", ".toml")
+
+
+class ConfigLoaderError(RuntimeError):
+    """Raised when a configuration file cannot be loaded or validated."""
+
+
+def _load_raw_payload(path: Path) -> dict[str, Any]:
+    try:
+        payload = path.read_text(encoding="utf-8")
+    except OSError as exc:  # pragma: no cover - file system failures are rare
+        msg = f"Failed to read configuration file at {path}"
+        raise ConfigLoaderError(msg) from exc
+
+    suffix = path.suffix.lower()
+    if suffix in {".yaml", ".yml"}:
+        data = yaml.safe_load(payload)
+    elif suffix == ".toml":
+        data = tomllib.loads(payload)
+    else:  # pragma: no cover - guarded by caller
+        msg = f"Unsupported configuration format: {suffix}"
+        raise ConfigLoaderError(msg)
+
+    if not isinstance(data, dict):
+        msg = (
+            "Configuration files must define a mapping at the top level, "
+            f"found {type(data).__name__}"
+        )
+        raise ConfigLoaderError(msg)
+    return data
+
+
+def load_profile(path: Path) -> SimulationProfile:
+    """Load and validate a configuration profile from ``path``."""
+
+    if path.suffix.lower() not in SUPPORTED_SUFFIXES:
+        msg = f"Unsupported configuration file suffix: {path.suffix}"
+        raise ConfigLoaderError(msg)
+
+    raw_data = _load_raw_payload(path)
+    try:
+        return SimulationProfile.model_validate(raw_data)
+    except ValidationError as exc:  # pragma: no cover - validation tested separately
+        msg = f"Failed to validate configuration file {path}"
+        raise ConfigLoaderError(msg) from exc
+
+
+@dataclass(slots=True)
+class ConfigLoader:
+    """Resolve and load configuration profiles from a directory."""
+
+    root: Path
+
+    def __post_init__(self) -> None:
+        self.root = self.root.expanduser().resolve()
+
+    def _candidate_paths(self, profile_name: str) -> Iterable[Path]:
+        for suffix in SUPPORTED_SUFFIXES:
+            yield self.root / f"{profile_name}{suffix}"
+
+    def load(self, profile_name: str) -> SimulationProfile:
+        """Load ``profile_name`` using one of the supported suffixes."""
+
+        for path in self._candidate_paths(profile_name):
+            if path.exists():
+                return load_profile(path)
+        msg = (
+            f"Could not find profile '{profile_name}' in {self.root}. "
+            f"Expected suffixes: {', '.join(SUPPORTED_SUFFIXES)}"
+        )
+        raise ConfigLoaderError(msg)

--- a/sim/src/ki_dev_tycoon/config/schemas.py
+++ b/sim/src/ki_dev_tycoon/config/schemas.py
@@ -1,0 +1,60 @@
+"""Pydantic schemas describing simulation configuration files."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from pydantic import BaseModel, ConfigDict, Field
+
+if TYPE_CHECKING:  # pragma: no cover - import guarded for type checking only
+    from ki_dev_tycoon.app import SimulationConfig
+
+
+class EconomyConfig(BaseModel):
+    """Economic parameters for a simulation profile."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    daily_active_users: int = Field(
+        ge=0,
+        description="Projected daily active users in the simulated company.",
+    )
+    arp_dau: float = Field(
+        ge=0.0,
+        description="Average revenue per daily active user in Euro.",
+    )
+    operating_costs: float = Field(
+        ge=0.0,
+        description="Daily operating costs in Euro.",
+    )
+
+
+class SimulationProfile(BaseModel):
+    """Top-level schema for simulation configuration files."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    name: str = Field(description="Unique identifier for the profile.")
+    description: str | None = Field(
+        default=None, description="Optional human readable description."
+    )
+    ticks: int = Field(gt=0, description="Number of ticks the simulation should run.")
+    seed: int = Field(
+        description="Deterministic random seed used to initialise the RNG.",
+    )
+    economy: EconomyConfig = Field(
+        description="Economic parameters controlling cashflow computations.",
+    )
+
+    def to_simulation_config(self) -> SimulationConfig:
+        """Convert the profile into :class:`~ki_dev_tycoon.app.SimulationConfig`."""
+
+        from ki_dev_tycoon.app import SimulationConfig
+
+        return SimulationConfig(
+            ticks=self.ticks,
+            seed=self.seed,
+            daily_active_users=self.economy.daily_active_users,
+            arp_dau=self.economy.arp_dau,
+            operating_costs=self.economy.operating_costs,
+        )

--- a/sim/src/ki_dev_tycoon/core/__init__.py
+++ b/sim/src/ki_dev_tycoon/core/__init__.py
@@ -1,6 +1,17 @@
 """Core infrastructure for deterministic simulation."""
 
+from .events import EventBus, SimulationCompleted, SimulationEvent, SimulationStarted, TickProcessed
 from .rng import RandomSource
 from .time import FrozenTime, TickClock, TimeProvider
 
-__all__ = ["RandomSource", "TickClock", "TimeProvider", "FrozenTime"]
+__all__ = [
+    "EventBus",
+    "RandomSource",
+    "TickClock",
+    "TimeProvider",
+    "FrozenTime",
+    "SimulationEvent",
+    "SimulationStarted",
+    "TickProcessed",
+    "SimulationCompleted",
+]

--- a/sim/src/ki_dev_tycoon/core/events.py
+++ b/sim/src/ki_dev_tycoon/core/events.py
@@ -1,0 +1,80 @@
+"""Publish/subscribe infrastructure for simulation events."""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from dataclasses import dataclass
+from typing import Callable, Dict, List
+
+
+@dataclass(slots=True, frozen=True)
+class SimulationEvent:
+    """Base type for all simulation events."""
+
+
+@dataclass(slots=True, frozen=True)
+class SimulationStarted(SimulationEvent):
+    """Emitted once the simulation loop has been initialised."""
+
+    seed: int
+
+
+@dataclass(slots=True, frozen=True)
+class TickProcessed(SimulationEvent):
+    """Emitted after a simulation tick has finished processing."""
+
+    tick: int
+
+
+@dataclass(slots=True, frozen=True)
+class SimulationCompleted(SimulationEvent):
+    """Emitted when the simulation loop terminates successfully."""
+
+    tick: int
+
+
+EventHandler = Callable[[SimulationEvent], None]
+
+
+class EventBus:
+    """Simple synchronous event dispatcher."""
+
+    def __init__(self) -> None:
+        self._subscribers: Dict[type[SimulationEvent], List[EventHandler]] = defaultdict(list)
+
+    def subscribe(
+        self, event_type: type[SimulationEvent], handler: EventHandler
+    ) -> None:
+        """Register ``handler`` to receive ``event_type`` instances."""
+
+        handlers = self._subscribers[event_type]
+        if handler not in handlers:
+            handlers.append(handler)  # preserve registration order
+
+    def unsubscribe(
+        self, event_type: type[SimulationEvent], handler: EventHandler
+    ) -> None:
+        """Remove ``handler`` from the subscriber list for ``event_type``."""
+
+        handlers = self._subscribers.get(event_type)
+        if not handlers:
+            return
+        try:
+            handlers.remove(handler)
+        except ValueError:  # handler not registered
+            return
+        if not handlers:
+            del self._subscribers[event_type]
+
+    def publish(self, event: SimulationEvent) -> None:
+        """Emit ``event`` to all subscribers synchronously."""
+
+        for event_type, handlers in list(self._subscribers.items()):
+            if isinstance(event, event_type):
+                for handler in list(handlers):
+                    handler(event)
+
+    def clear(self) -> None:
+        """Remove all registered subscribers."""
+
+        self._subscribers.clear()

--- a/sim/src/ki_dev_tycoon/persistence/__init__.py
+++ b/sim/src/ki_dev_tycoon/persistence/__init__.py
@@ -1,0 +1,14 @@
+"""Persistence helpers for serialising simulation state."""
+
+from __future__ import annotations
+
+from .savegame import SaveGame, SaveGameError, decode_savegame, encode_savegame, load_game, save_game
+
+__all__ = [
+    "SaveGame",
+    "SaveGameError",
+    "decode_savegame",
+    "encode_savegame",
+    "load_game",
+    "save_game",
+]

--- a/sim/src/ki_dev_tycoon/persistence/savegame.py
+++ b/sim/src/ki_dev_tycoon/persistence/savegame.py
@@ -1,0 +1,82 @@
+"""Serialization helpers for the immutable :class:`~ki_dev_tycoon.core.state.GameState`."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Mapping
+
+from ki_dev_tycoon.core.state import GameState
+
+CURRENT_VERSION = 1
+
+
+class SaveGameError(RuntimeError):
+    """Raised when a savegame cannot be parsed or validated."""
+
+
+@dataclass(slots=True, frozen=True)
+class SaveGame:
+    """Container representing an encoded savegame."""
+
+    state: GameState
+    version: int = CURRENT_VERSION
+
+    def to_dict(self) -> dict[str, Any]:
+        return {"version": self.version, "state": self.state.to_dict()}
+
+    @classmethod
+    def from_dict(cls, payload: Mapping[str, Any]) -> "SaveGame":
+        try:
+            version = int(payload["version"])
+            raw_state = payload["state"]
+        except KeyError as exc:  # pragma: no cover - defensive guard
+            msg = "Malformed savegame payload"
+            raise SaveGameError(msg) from exc
+
+        if version != CURRENT_VERSION:
+            msg = f"Unsupported savegame version: {version}"
+            raise SaveGameError(msg)
+        if not isinstance(raw_state, Mapping):
+            msg = "Savegame payload must contain a state mapping"
+            raise SaveGameError(msg)
+        return cls(state=GameState.from_dict(raw_state), version=version)
+
+
+def encode_savegame(save: SaveGame) -> str:
+    """Return a canonical JSON representation for ``save``."""
+
+    return json.dumps(save.to_dict(), separators=(",", ":"), sort_keys=True)
+
+
+def decode_savegame(serialised: str) -> SaveGame:
+    """Parse ``serialised`` JSON into a :class:`SaveGame`."""
+
+    try:
+        payload = json.loads(serialised)
+    except json.JSONDecodeError as exc:
+        msg = "Failed to decode savegame JSON"
+        raise SaveGameError(msg) from exc
+    if not isinstance(payload, dict):
+        msg = "Savegame JSON must decode into an object"
+        raise SaveGameError(msg)
+    return SaveGame.from_dict(payload)
+
+
+def save_game(path: Path, state: GameState) -> None:
+    """Write ``state`` to ``path`` using the canonical save format."""
+
+    payload = encode_savegame(SaveGame(state=state))
+    path.write_text(payload + "\n", encoding="utf-8")
+
+
+def load_game(path: Path) -> GameState:
+    """Load a :class:`GameState` snapshot from ``path``."""
+
+    try:
+        buffer = path.read_text(encoding="utf-8")
+    except OSError as exc:  # pragma: no cover - propagated to caller
+        msg = f"Failed to read savegame at {path}"
+        raise SaveGameError(msg) from exc
+    return decode_savegame(buffer).state

--- a/sim/tests/unit/test_config_loader.py
+++ b/sim/tests/unit/test_config_loader.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from ki_dev_tycoon.config import (
+    ConfigLoader,
+    ConfigLoaderError,
+    EconomyConfig,
+    SimulationProfile,
+    load_profile,
+)
+
+
+def fixture_path(relative: str) -> Path:
+    return Path(__file__).resolve().parents[2] / relative
+
+
+def test_load_profile_from_yaml() -> None:
+    profile_path = fixture_path("config/profiles/default.yaml")
+
+    profile = load_profile(profile_path)
+
+    assert profile.name == "default"
+    assert profile.ticks == 30
+    assert profile.economy.daily_active_users == 5_000
+    assert profile.economy.arp_dau == pytest.approx(0.12)
+
+
+def test_simulation_profile_converts_to_runtime_config() -> None:
+    profile = SimulationProfile(
+        name="custom",
+        ticks=15,
+        seed=7,
+        economy=EconomyConfig(
+            daily_active_users=1_000,
+            arp_dau=0.25,
+            operating_costs=300.0,
+        ),
+    )
+
+    config = profile.to_simulation_config()
+
+    assert config.ticks == 15
+    assert config.seed == 7
+    assert config.daily_active_users == 1_000
+    assert config.arp_dau == pytest.approx(0.25)
+    assert config.operating_costs == pytest.approx(300.0)
+
+
+def test_config_loader_finds_profile_by_suffix(tmp_path: Path) -> None:
+    target = tmp_path / "baseline.toml"
+    target.write_text(
+        """
+name = "default"
+ticks = 8
+seed = 99
+
+[economy]
+daily_active_users = 200
+arp_dau = 0.5
+operating_costs = 100.0
+""".strip(),
+        encoding="utf-8",
+    )
+
+    loader = ConfigLoader(tmp_path)
+
+    profile = loader.load("baseline")
+
+    assert profile.ticks == 8
+    assert profile.seed == 99
+    assert profile.economy.operating_costs == pytest.approx(100.0)
+
+
+def test_load_profile_requires_mapping(tmp_path: Path) -> None:
+    source = tmp_path / "bad.yaml"
+    source.write_text("- 1\n- 2\n", encoding="utf-8")
+
+    with pytest.raises(ConfigLoaderError):
+        load_profile(source)
+
+
+def test_config_loader_reports_missing_profile(tmp_path: Path) -> None:
+    loader = ConfigLoader(tmp_path)
+
+    with pytest.raises(ConfigLoaderError):
+        loader.load("nonexistent")

--- a/sim/tests/unit/test_events.py
+++ b/sim/tests/unit/test_events.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+from typing import List
+
+from ki_dev_tycoon.app import SimulationConfig, run_simulation
+from ki_dev_tycoon.core.events import (
+    EventBus,
+    SimulationCompleted,
+    SimulationEvent,
+    SimulationStarted,
+    TickProcessed,
+)
+
+
+def test_event_bus_collects_simulation_events() -> None:
+    bus = EventBus()
+    received: List[SimulationEvent] = []
+
+    def handler(event: SimulationEvent) -> None:
+        received.append(event)
+
+    bus.subscribe(SimulationEvent, handler)
+    config = SimulationConfig(
+        ticks=2,
+        seed=123,
+        daily_active_users=100,
+        arp_dau=0.2,
+        operating_costs=10.0,
+    )
+
+    run_simulation(config, event_bus=bus)
+
+    assert len(received) == 4
+    assert received[0] == SimulationStarted(seed=123)
+    assert received[1] == TickProcessed(tick=1)
+    assert received[2] == TickProcessed(tick=2)
+    assert received[3] == SimulationCompleted(tick=2)
+
+
+def test_event_bus_unsubscribe_is_noop_when_missing() -> None:
+    bus = EventBus()
+    calls: List[int] = []
+
+    def handler(event: SimulationEvent) -> None:
+        calls.append(1)
+
+    bus.subscribe(TickProcessed, handler)
+    bus.unsubscribe(TickProcessed, handler)
+    bus.unsubscribe(TickProcessed, handler)
+
+    bus.publish(TickProcessed(tick=5))
+
+    assert calls == []

--- a/sim/tests/unit/test_savegame.py
+++ b/sim/tests/unit/test_savegame.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from ki_dev_tycoon.core.state import GameState
+from ki_dev_tycoon.persistence.savegame import (
+    SaveGame,
+    SaveGameError,
+    decode_savegame,
+    encode_savegame,
+    load_game,
+    save_game,
+)
+
+
+def test_savegame_roundtrip(tmp_path: Path) -> None:
+    state = GameState(tick=7, cash=250.5, reputation=60.0)
+    target = tmp_path / "save.json"
+
+    save_game(target, state)
+    loaded = load_game(target)
+
+    assert loaded == state
+
+
+def test_encode_and_decode_are_inverse_operations() -> None:
+    state = GameState(tick=1, cash=0.0, reputation=50.0)
+    save = SaveGame(state=state)
+
+    serialised = encode_savegame(save)
+    decoded = decode_savegame(serialised)
+
+    assert decoded.state == state
+    assert decoded.version == save.version
+
+
+def test_decode_savegame_rejects_invalid_payload() -> None:
+    with pytest.raises(SaveGameError):
+        decode_savegame("{}")


### PR DESCRIPTION
## Summary
- add a schema-driven YAML/TOML configuration loader and ship a default profile
- introduce a synchronous event bus, wire it into the simulation loop, and cover it with tests
- implement JSON savegame helpers with round-trip validation and mark the corresponding roadmap steps as complete

## Testing
- poetry run pytest

------
https://chatgpt.com/codex/tasks/task_e_68e3aa72e884832799fa5097b23e46e7