### PR TITLE
feat: bootstrap client mock and API stub

### DIFF
--- a/100_schritte_plan.md
+++ b/100_schritte_plan.md
@@ -22,8 +22,8 @@
 12. [x] **Ereignisbus (EventBus):** Publish/Subscribe-Grundgerüst; leere Events für spätere Systeme.
 13. [x] **Persistenz-Roundtrip:** `savegame.py` (JSON) + Test `state == load(save(state))`.
 14. [x] **Benchmark-Skeleton:** pytest-benchmark setuppen; Basis-Messung für Tick-Loop einfrieren.
-15. [ ] **Client-Projekt initialisieren:** Leere Szenen/Scenes (Dashboard-Mock), Build-Pipeline lauffähig.
-16. [ ] **API-Adapter (optional):** FastAPI-Stub mit `/state` (GET) → Client liest Dummy-State.
+15. [x] **Client-Projekt initialisieren:** Leere Szenen/Scenes (Dashboard-Mock), Build-Pipeline lauffähig.
+16. [x] **API-Adapter (optional):** FastAPI-Stub mit `/state` (GET) → Client liest Dummy-State.
 17. [ ] **Fehlerklassen:** Domänen-Exception-Hierarchie + zentraler Handler im Sim-Kernel.
 18. [ ] **Feature-Flags:** Remote-Config-Keypfad definieren; lokale Fallbacks implementieren.
 19. [ ] **Risikoregister aufsetzen:** Top-5 Risiken + Frühindikatoren + Response-Owner.

--- a/client/README.md
+++ b/client/README.md
@@ -1,14 +1,49 @@
-# KI-Dev-Tycoon Client (Placeholder)
+# KI-Dev-Tycoon Client
 
-Dieser Ordner reserviert den Platz für das künftige Unity- bzw. Godot-Projekt des Mobile-Clients. Für die Foundations-Phase dient er als Strukturanker im Monorepo.
+Dieses Verzeichnis enthält den Godot-Prototypen für die Foundations-Phase. Der Fokus liegt aktuell darauf, ein lauffähiges Projektgerüst mit Mock-Szenen zu besitzen, das später mit den Daten des Simulations-Kernels verbunden wird.
 
-## Aktueller Status
+## Projektstruktur
 
-* Noch kein Engine-Projekt eingecheckt.
-* Build- und CI-Pipelines folgen nach Abschluss der Kern-Simulationsarbeiten.
+```
+client/
+  godot_project/
+    project.godot          # Godot 4 Konfigurationsdatei
+    scenes/
+      dashboard.tscn       # UI-Mock des Dashboards
+      project_list.tscn    # Wiederverwendbarer Projektslisten-Container
+      resources/
+        title_label.tres   # LabelSettings für den Screen-Titel
+    scripts/
+      project_list_preview.gd  # Renderlogik für Mock-Daten
+  tools/
+    build.py               # Build/Export-Orchestrierung
+```
+
+## Voraussetzungen
+
+* Godot 4.2.x oder neuer muss lokal installiert und über den Befehl `godot4` verfügbar sein.
+* Python 3.11+ für die Build-Hilfsskripte.
+
+## Build Pipeline
+
+Das Skript `tools/build.py` exportiert die Szenen in ein Distributionsverzeichnis (standardmäßig `build/web`). Es erzeugt eine minimale `index.html`, bindet die Godot-Exportdateien ein (sobald verfügbar) und schreibt Metadaten (z. B. Build-Timestamp).
+
+```bash
+cd client
+python -m pip install -r tools/requirements.txt  # optional: linting utilities
+python tools/build.py --export web --output build/web
+```
+
+Der Export nutzt den Godot-CLI-Aufruf
+
+```bash
+godot4 --headless --path godot_project --export-release "Web" build/web/KI-Dev-Tycoon.html
+```
+
+Falls der CLI-Befehl nicht gefunden wird oder `--mock-export` gesetzt ist, generiert das Skript einen Platzhalter-Build (HTML + Szenenliste) und erstellt trotzdem das ZIP-Artefakt (`build/KI-Dev-Tycoon-web.zip`). Dadurch bleibt die Pipeline auch ohne Godot-Binary ausführbar.
 
 ## Nächste Schritte
 
-1. Engine auswählen (Unity oder Godot) und Basisprojekt initialisieren.
-2. Mock-Szenen (Dashboard, Projektliste) erstellen, um Daten aus dem Simulations-Kernel visualisieren zu können.
-3. API/SDK-Anbindung zum `sim`-Paket vorbereiten.
+1. Szenen mit realen Daten aus der Simulation befüllen (Schritt 16 ff.).
+2. UI-Komponenten modularisieren und gestylte Themes erstellen.
+3. Automatisierte UI-Tests (Godot GUT) vorbereiten.

--- a/client/godot_project/project.godot
+++ b/client/godot_project/project.godot
@@ -1,0 +1,17 @@
+; Engine configuration file.
+; Manual scaffold for KI-Dev-Tycoon client mockup.
+
+config_version=5
+
+[application]
+config/name="KI Dev Tycoon Client"
+run/main_scene="res://scenes/dashboard.tscn"
+config/features=PackedStringArray("4.2", "Forward Plus")
+
+[rendering]
+renderer/rendering_method="forward_plus"
+
+[display]
+window/size/width=1280
+window/size/height=720
+window/stretch/mode="canvas_items"

--- a/client/godot_project/scenes/dashboard.tscn
+++ b/client/godot_project/scenes/dashboard.tscn
@@ -1,0 +1,56 @@
+[gd_scene load_steps=3 format=3]
+
+[node name="Dashboard" type="Control"]
+layout_mode = 3
+anchor_right = 1.0
+anchor_bottom = 1.0
+
+[node name="Margin" type="MarginContainer" parent="."]
+layout_mode = 2
+anchor_right = 1.0
+anchor_bottom = 1.0
+custom_constants/margin_left = 24
+custom_constants/margin_top = 24
+custom_constants/margin_right = 24
+custom_constants/margin_bottom = 24
+
+[node name="VBox" type="VBoxContainer" parent="Margin"]
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_vertical = 3
+custom_constants/separation = 16
+
+[node name="Title" type="Label" parent="Margin/VBox"]
+layout_mode = 2
+text = "KI Dev Tycoon"
+label_settings = NodePath("res://scenes/resources/title_label.tres")
+
+[node name="Subtitle" type="Label" parent="Margin/VBox"]
+layout_mode = 2
+text = "Dashboard Mock"
+
+[node name="Description" type="RichTextLabel" parent="Margin/VBox"]
+layout_mode = 2
+size_flags_vertical = 3
+fit_content = true
+text = "[b]Ziel[/b]: Visualisierung der Simulationsdaten.\n\nDieser Mock dient als Platzhalter f\u00fcr zuk\u00fcnftige UI-Widgets."
+
+[node name="ProjectListPreview" type="Control" parent="Margin/VBox"]
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_vertical = 3
+custom_minimum_size = Vector2(0, 280)
+script = ExtResource("res://scripts/project_list_preview.gd")
+
+[node name="Footer" type="HBoxContainer" parent="Margin/VBox"]
+layout_mode = 2
+size_flags_horizontal = 3
+alignment = 2
+
+[node name="VersionLabel" type="Label" parent="Margin/VBox/Footer"]
+layout_mode = 2
+text = "Build: dev"
+
+[node name="ExportButton" type="Button" parent="Margin/VBox/Footer"]
+layout_mode = 2
+text = "Export Placeholder"

--- a/client/godot_project/scenes/project_list.tscn
+++ b/client/godot_project/scenes/project_list.tscn
@@ -1,0 +1,7 @@
+[gd_scene load_steps=2 format=3]
+
+[node name="ProjectList" type="Control"]
+layout_mode = 3
+anchor_right = 1.0
+anchor_bottom = 1.0
+script = ExtResource("res://scripts/project_list_preview.gd")

--- a/client/godot_project/scenes/resources/title_label.tres
+++ b/client/godot_project/scenes/resources/title_label.tres
@@ -1,0 +1,6 @@
+[gd_resource type="LabelSettings" load_steps=2 format=3]
+
+[resource]
+font_size = 42
+uppercase = true
+outline_size = 1

--- a/client/godot_project/scripts/project_list_preview.gd
+++ b/client/godot_project/scripts/project_list_preview.gd
@@ -1,0 +1,87 @@
+extends Control
+
+## Placeholder script that mirrors how the dashboard would request
+## project data from the simulation kernel once the API is wired up.
+## For now, we show static mock entries that match the research focus
+## of the first playable prototype.
+
+@export var mock_projects := [
+    {
+        "name": "Project Helios",
+        "type": "Chatbot",
+        "status": "Planning",
+        "eta_days": 45,
+    },
+    {
+        "name": "Aurora QA",
+        "type": "Tooling",
+        "status": "Training",
+        "eta_days": 12,
+    },
+    {
+        "name": "Muse Support",
+        "type": "Chatbot",
+        "status": "Released",
+        "eta_days": 0,
+    },
+]
+
+var _list_container: VBoxContainer
+
+func _ready() -> void:
+    _ensure_list_container()
+    _render_mock_rows()
+
+func _ensure_list_container() -> void:
+    if _list_container:
+        return
+    _list_container = VBoxContainer.new()
+    _list_container.name = "MockList"
+    _list_container.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+    _list_container.size_flags_vertical = Control.SIZE_EXPAND_FILL
+    _list_container.custom_minimum_size = Vector2(0, 200)
+    add_child(_list_container)
+
+func _render_mock_rows() -> void:
+    _clear_children(_list_container)
+    for project in mock_projects:
+        var panel := PanelContainer.new()
+        panel.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+        panel.add_theme_constant_override("margin_top", 8)
+        panel.add_theme_constant_override("margin_bottom", 8)
+        panel.add_theme_constant_override("margin_left", 12)
+        panel.add_theme_constant_override("margin_right", 12)
+
+        var hbox := HBoxContainer.new()
+        hbox.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+        hbox.custom_minimum_size = Vector2(0, 48)
+
+        var name_label := Label.new()
+        name_label.text = "%s (%s)" % [project.get("name", "Unnamed"), project.get("type", "-")]
+        name_label.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+        name_label.horizontal_alignment = HORIZONTAL_ALIGNMENT_LEFT
+
+        var status_label := Label.new()
+        status_label.text = project.get("status", "?")
+        status_label.size_flags_horizontal = Control.SIZE_FILL
+        status_label.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
+
+        var eta_label := Label.new()
+        eta_label.text = _format_eta(project.get("eta_days", 0))
+        eta_label.horizontal_alignment = HORIZONTAL_ALIGNMENT_RIGHT
+
+        hbox.add_child(name_label)
+        hbox.add_child(status_label)
+        hbox.add_child(eta_label)
+
+        panel.add_child(hbox)
+        _list_container.add_child(panel)
+
+func _format_eta(days: int) -> String:
+    if days <= 0:
+        return "Live"
+    return "%d d" % days
+
+func _clear_children(container: Node) -> void:
+    for child in container.get_children():
+        child.queue_free()

--- a/client/tools/build.py
+++ b/client/tools/build.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python3
+"""Utility to export the Godot client mock for KI-Dev-Tycoon.
+
+The script wraps the Godot CLI to provide a reproducible build pipeline
+that can be executed locally or from CI. When the Godot binary is not
+available (e.g. on CI smoke runs without the engine), the script falls
+back to a mock export that still packages the project assets so that
+later steps in the pipeline can operate on deterministic artefacts.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import subprocess
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Final
+
+ROOT: Final[Path] = Path(__file__).resolve().parent.parent
+PROJECT_DIR: Final[Path] = ROOT / "godot_project"
+DEFAULT_BUILD_DIR: Final[Path] = ROOT / "build"
+ZIP_NAME_TEMPLATE: Final[str] = "KI-Dev-Tycoon-{export}.zip"
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Build the KI-Dev-Tycoon client mock")
+    parser.add_argument(
+        "--export",
+        choices=("web",),
+        default="web",
+        help="Name of the export preset to use.",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        help="Output directory for the exported artefacts (defaults to build/<export>).",
+    )
+    parser.add_argument(
+        "--godot-bin",
+        default=Path(shutil.which("godot4") or "godot4"),
+        help="Path to the Godot executable (defaults to `godot4` on PATH).",
+    )
+    parser.add_argument(
+        "--mock-export",
+        action="store_true",
+        help="Skip the Godot CLI invocation and only create placeholder artefacts.",
+    )
+    return parser.parse_args()
+
+
+def ensure_project_exists() -> None:
+    if not PROJECT_DIR.exists():
+        raise SystemExit(f"Godot project directory not found: {PROJECT_DIR}")
+
+
+def run_godot_export(godot_bin: str | Path, export_name: str, output_dir: Path) -> bool:
+    export_targets = {
+        "web": {
+            "preset": "Web",
+            "filename": "KI-Dev-Tycoon.html",
+        }
+    }
+    target = export_targets[export_name]
+    output_file = output_dir / target["filename"]
+    cmd = [
+        str(godot_bin),
+        "--headless",
+        "--path",
+        str(PROJECT_DIR),
+        "--export-release",
+        target["preset"],
+        str(output_file),
+    ]
+    try:
+        subprocess.run(cmd, check=True)
+        return True
+    except FileNotFoundError:
+        return False
+    except subprocess.CalledProcessError as exc:  # pragma: no cover - requires Godot
+        raise SystemExit(f"Godot export failed with exit code {exc.returncode}.") from exc
+
+
+def create_placeholder_bundle(export_name: str, output_dir: Path) -> None:
+    scenes_dir = PROJECT_DIR / "scenes"
+    output_dir.mkdir(parents=True, exist_ok=True)
+    placeholder = output_dir / "index.html"
+    placeholder.write_text(
+        """<!doctype html>
+<html lang=\"en\">
+  <head>
+    <meta charset=\"utf-8\" />
+    <title>KI Dev Tycoon – Placeholder Build</title>
+    <style>body{font-family:system-ui;background:#10131a;color:#f1f5f9;padding:3rem;}code{background:#1e293b;padding:0.1rem 0.3rem;border-radius:4px;}</style>
+  </head>
+  <body>
+    <h1>KI Dev Tycoon</h1>
+    <p>Der echte {export_name}-Export wird erzeugt, sobald der Godot-CLI in der CI/CD-Pipeline verfügbar ist.</p>
+    <p>Bis dahin enthält dieses Artefakt statische Szenen-Dateien als Referenz.</p>
+  </body>
+</html>
+"""
+    )
+    scenes_snapshot = output_dir / "scenes.json"
+    scenes_snapshot.write_text(
+        json.dumps(
+            sorted(str(p.relative_to(PROJECT_DIR)) for p in scenes_dir.rglob("*.tscn")),
+        )
+    )
+
+
+def write_metadata(export_name: str, output_dir: Path, used_mock: bool) -> None:
+    metadata = {
+        "export": export_name,
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "project_dir": str(PROJECT_DIR),
+        "output_dir": str(output_dir),
+        "mock": used_mock,
+    }
+    (output_dir / "build_metadata.json").write_text(json.dumps(metadata, indent=2))
+
+
+def create_zip_archive(export_name: str, output_dir: Path) -> Path:
+    archive_dir = DEFAULT_BUILD_DIR
+    archive_dir.mkdir(parents=True, exist_ok=True)
+    archive_path = archive_dir / ZIP_NAME_TEMPLATE.format(export=export_name)
+    if archive_path.exists():
+        archive_path.unlink()
+    shutil.make_archive(str(archive_path.with_suffix("")), "zip", root_dir=output_dir)
+    return archive_path
+
+
+def main() -> None:
+    args = parse_args()
+    ensure_project_exists()
+
+    output_dir = args.output or DEFAULT_BUILD_DIR / args.export
+    output_dir = output_dir.resolve()
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    godot_available = shutil.which(str(args.godot_bin)) is not None
+    used_mock = bool(args.mock_export or not godot_available)
+
+    if not used_mock:
+        exported = run_godot_export(args.godot_bin, args.export, output_dir)
+        if not exported:
+            print("Godot binary not found – falling back to placeholder export.")
+            used_mock = True
+
+    if used_mock:
+        create_placeholder_bundle(args.export, output_dir)
+
+    write_metadata(args.export, output_dir, used_mock)
+    archive_path = create_zip_archive(args.export, output_dir)
+    print(f"Artefacts written to {output_dir}")
+    print(f"ZIP archive available at {archive_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/client/tools/requirements.txt
+++ b/client/tools/requirements.txt
@@ -1,0 +1,2 @@
+# Optional developer tooling for the client build pipeline.
+# Add linting or export helpers here once needed.

--- a/sim/README.md
+++ b/sim/README.md
@@ -28,6 +28,18 @@ poetry run ki-sim --ticks 30 --seed 42 \
 
 Das Kommando gibt einen JSON-Snapshot mit Kapital- und Reputationswerten auf stdout aus.
 
+## API-Adapter (Preview)
+
+Der optionale FastAPI-Adapter stellt unter `/state` einen deterministischen Dummy-State bereit. Er dient aktuell dazu, den Client-Mock (Schritt 15) mit strukturierten Daten zu versorgen.
+
+```bash
+poetry run uvicorn ki_dev_tycoon.api.app:app --reload
+# oder als Python-Modul:
+poetry run python -m uvicorn ki_dev_tycoon.api.app:app --reload
+```
+
+Die Antwortstruktur wird über Pydantic-DTOs in `ki_dev_tycoon/api/dto.py` beschrieben.
+
 ## Tests
 
 ```bash

--- a/sim/poetry.lock
+++ b/sim/poetry.lock
@@ -13,6 +13,26 @@ files = [
 ]
 
 [[package]]
+name = "anyio"
+version = "4.11.0"
+description = "High-level concurrency and networking framework on top of asyncio or Trio"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "anyio-4.11.0-py3-none-any.whl", hash = "sha256:0287e96f4d26d4149305414d4e3bc32f0dcd0862365a4bddea19d7a1ec38c4fc"},
+    {file = "anyio-4.11.0.tar.gz", hash = "sha256:82a8d0b81e318cc5ce71a5f1f8b5c4e63619620b63141ef8c995fa0db95a57c4"},
+]
+
+[package.dependencies]
+idna = ">=2.8"
+sniffio = ">=1.1"
+typing_extensions = {version = ">=4.5", markers = "python_version < \"3.13\""}
+
+[package.extras]
+trio = ["trio (>=0.31.0)"]
+
+[[package]]
 name = "argcomplete"
 version = "3.6.2"
 description = "Bash tab completion for argparse"
@@ -163,6 +183,27 @@ files = [
 ]
 
 [[package]]
+name = "fastapi"
+version = "0.115.14"
+description = "FastAPI framework, high performance, easy to learn, fast to code, ready for production"
+optional = false
+python-versions = ">=3.8"
+groups = ["main"]
+files = [
+    {file = "fastapi-0.115.14-py3-none-any.whl", hash = "sha256:6c0c8bf9420bd58f565e585036d971872472b4f7d3f6c73b698e10cffdefb3ca"},
+    {file = "fastapi-0.115.14.tar.gz", hash = "sha256:b1de15cdc1c499a4da47914db35d0e4ef8f1ce62b624e94e0e5824421df99739"},
+]
+
+[package.dependencies]
+pydantic = ">=1.7.4,<1.8 || >1.8,<1.8.1 || >1.8.1,<2.0.0 || >2.0.0,<2.0.1 || >2.0.1,<2.1.0 || >2.1.0,<3.0.0"
+starlette = ">=0.40.0,<0.47.0"
+typing-extensions = ">=4.8.0"
+
+[package.extras]
+all = ["email-validator (>=2.0.0)", "fastapi-cli[standard] (>=0.0.5)", "httpx (>=0.23.0)", "itsdangerous (>=1.1.0)", "jinja2 (>=3.1.5)", "orjson (>=3.2.1)", "pydantic-extra-types (>=2.0.0)", "pydantic-settings (>=2.0.0)", "python-multipart (>=0.0.18)", "pyyaml (>=5.3.1)", "ujson (>=4.0.1,!=4.0.2,!=4.1.0,!=4.2.0,!=4.3.0,!=5.0.0,!=5.1.0)", "uvicorn[standard] (>=0.12.0)"]
+standard = ["email-validator (>=2.0.0)", "fastapi-cli[standard] (>=0.0.5)", "httpx (>=0.23.0)", "jinja2 (>=3.1.5)", "python-multipart (>=0.0.18)", "uvicorn[standard] (>=0.12.0)"]
+
+[[package]]
 name = "filelock"
 version = "3.19.1"
 description = "A platform independent file lock."
@@ -222,6 +263,21 @@ files = [
 
 [package.extras]
 license = ["ukkonen"]
+
+[[package]]
+name = "idna"
+version = "3.10"
+description = "Internationalized Domain Names in Applications (IDNA)"
+optional = false
+python-versions = ">=3.6"
+groups = ["main"]
+files = [
+    {file = "idna-3.10-py3-none-any.whl", hash = "sha256:946d195a0d259cbba61165e88e65941f16e9b36ea6ddb97f00452bae8b1287d3"},
+    {file = "idna-3.10.tar.gz", hash = "sha256:12f65c9b470abda6dc35cf8e63cc574b1c52b11df2c86030af0ac09b01b13ea9"},
+]
+
+[package.extras]
+all = ["flake8 (>=7.1.1)", "mypy (>=1.11.2)", "pytest (>=8.3.2)", "ruff (>=0.6.2)"]
 
 [[package]]
 name = "iniconfig"
@@ -748,6 +804,18 @@ files = [
 ]
 
 [[package]]
+name = "sniffio"
+version = "1.3.1"
+description = "Sniff out which async library your code is running under"
+optional = false
+python-versions = ">=3.7"
+groups = ["main"]
+files = [
+    {file = "sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2"},
+    {file = "sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc"},
+]
+
+[[package]]
 name = "sortedcontainers"
 version = "2.4.0"
 description = "Sorted Containers -- Sorted List, Sorted Dict, Sorted Set"
@@ -758,6 +826,24 @@ files = [
     {file = "sortedcontainers-2.4.0-py2.py3-none-any.whl", hash = "sha256:a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0"},
     {file = "sortedcontainers-2.4.0.tar.gz", hash = "sha256:25caa5a06cc30b6b83d11423433f65d1f9d76c4c6a0c90e3379eaa43b9bfdb88"},
 ]
+
+[[package]]
+name = "starlette"
+version = "0.46.2"
+description = "The little ASGI library that shines."
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "starlette-0.46.2-py3-none-any.whl", hash = "sha256:595633ce89f8ffa71a015caed34a5b2dc1c0cdb3f0f1fbd1e69339cf2abeec35"},
+    {file = "starlette-0.46.2.tar.gz", hash = "sha256:7f7361f34eed179294600af672f565727419830b54b7b084efe44bb82d2fccd5"},
+]
+
+[package.dependencies]
+anyio = ">=3.6.2,<5"
+
+[package.extras]
+full = ["httpx (>=0.27.0,<0.29.0)", "itsdangerous", "jinja2", "python-multipart (>=0.0.18)", "pyyaml"]
 
 [[package]]
 name = "types-requests"
@@ -843,4 +929,4 @@ test = ["covdefaults (>=2.3)", "coverage (>=7.2.7)", "coverage-enable-subprocess
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.11"
-content-hash = "2238df3c96de43a5def6db4e3ecd335df30d67ba079b5569a49039782650a854"
+content-hash = "143a84ebf73f1bfe3a24b81e43794ae8ff44ec0377d5006bebcde2977be781e1"

--- a/sim/pyproject.toml
+++ b/sim/pyproject.toml
@@ -11,6 +11,7 @@ packages = [{ include = "ki_dev_tycoon", from = "src" }]
 python = "^3.11"
 pydantic = "^2.9.0"
 pyyaml = "^6.0.2"
+fastapi = "^0.115.0"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^8.3.3"

--- a/sim/src/ki_dev_tycoon/api/__init__.py
+++ b/sim/src/ki_dev_tycoon/api/__init__.py
@@ -1,0 +1,8 @@
+"""FastAPI adapter for the KI Dev Tycoon simulation kernel."""
+
+from __future__ import annotations
+
+from .app import app, create_app
+from .dto import SimulationStateDTO
+
+__all__ = ["app", "create_app", "SimulationStateDTO"]

--- a/sim/src/ki_dev_tycoon/api/app.py
+++ b/sim/src/ki_dev_tycoon/api/app.py
@@ -1,0 +1,52 @@
+"""FastAPI application that exposes a minimal `/state` endpoint."""
+
+from __future__ import annotations
+
+from fastapi import FastAPI
+
+from ki_dev_tycoon import __version__
+from ki_dev_tycoon.api.dto import ProjectPreviewDTO, SimulationStateDTO
+
+_DUMMY_STATE = SimulationStateDTO(
+    tick=120,
+    in_game_day=12,
+    reputation=72.5,
+    cash=250_000.0,
+    projects=[
+        ProjectPreviewDTO(
+            project_id="proj-aurora",
+            name="Aurora QA",
+            project_type="tooling",
+            stage="training",
+            quality=0.62,
+        ),
+        ProjectPreviewDTO(
+            project_id="proj-helix",
+            name="Project Helix",
+            project_type="chatbot",
+            stage="planning",
+            quality=0.15,
+        ),
+    ],
+)
+
+
+def create_app() -> FastAPI:
+    """Construct the FastAPI application instance."""
+
+    app = FastAPI(
+        title="KI Dev Tycoon API",
+        version=__version__,
+        description="Read-only adapter that exposes simulation state to the client prototype.",
+    )
+
+    @app.get("/state", response_model=SimulationStateDTO, tags=["State"])
+    async def read_state() -> SimulationStateDTO:
+        """Return a deterministic dummy state for the client mock."""
+
+        return _DUMMY_STATE
+
+    return app
+
+
+app = create_app()

--- a/sim/src/ki_dev_tycoon/api/dto.py
+++ b/sim/src/ki_dev_tycoon/api/dto.py
@@ -1,0 +1,38 @@
+"""Data transfer objects used by the FastAPI adapter."""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class ProjectPreviewDTO(BaseModel):
+    """Minimal representation of a simulated project for UI previews."""
+
+    model_config = ConfigDict(frozen=True)
+
+    project_id: str = Field(..., description="Stable identifier of the project instance.")
+    name: str = Field(..., description="Display name exposed to the client UI.")
+    project_type: Literal["chatbot", "tooling"] = Field(
+        ..., description="High-level category of the simulated project."
+    )
+    stage: Literal["planning", "training", "released"] = Field(
+        ..., description="Simplified project lifecycle stage."
+    )
+    quality: float = Field(..., ge=0.0, le=1.0, description="Quality score in [0, 1].")
+
+
+class SimulationStateDTO(BaseModel):
+    """Static snapshot returned by the `/state` endpoint."""
+
+    model_config = ConfigDict(frozen=True)
+
+    tick: int = Field(..., ge=0, description="Current simulation tick.")
+    in_game_day: int = Field(..., ge=0, description="Calendar day derived from the tick count.")
+    reputation: float = Field(..., ge=0.0, le=100.0, description="Public reputation of the studio.")
+    cash: float = Field(..., description="Liquid cash balance in game currency.")
+    projects: list[ProjectPreviewDTO] = Field(
+        default_factory=list,
+        description="Subset of projects visible on the dashboard.",
+    )

--- a/sim/tests/api/__init__.py
+++ b/sim/tests/api/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the FastAPI adapter."""

--- a/sim/tests/api/test_state_endpoint.py
+++ b/sim/tests/api/test_state_endpoint.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+from ki_dev_tycoon.api import SimulationStateDTO, create_app
+
+
+def test_state_endpoint_returns_deterministic_payload() -> None:
+    app = create_app()
+    client = TestClient(app)
+
+    response = client.get("/state")
+
+    assert response.status_code == 200
+    payload = SimulationStateDTO.model_validate(response.json())
+    assert payload.tick == 120
+    assert payload.in_game_day == 12
+    assert payload.reputation == 72.5
+    assert payload.projects[0].name == "Aurora QA"
+    assert payload.projects[1].project_type == "chatbot"


### PR DESCRIPTION
## Summary
- initialize a Godot-based client scaffold with dashboard and project list mock scenes
- add a reusable build helper that exports the client or produces a placeholder bundle when the Godot CLI is unavailable
- expose a FastAPI `/state` endpoint returning a deterministic dummy state and cover it with tests

## Testing
- python tools/build.py --mock-export
- poetry run pytest tests/api/test_state_endpoint.py -q


------
https://chatgpt.com/codex/tasks/task_e_68e40d58c69c83279b6baa8132746cb4