### PR TITLE
Align documentation with Steam MVP Zusatz spec

### DIFF
--- a/100_schritte_plan.md
+++ b/100_schritte_plan.md
@@ -1,126 +1,146 @@
-# 100-Schritte-Plan — KI-Dev-Tycoon (Arbeitsliste)
+# 100-Schritte-Plan — KI-Dev-Tycoon (Steam-MVP Solo-Dev)
 
-> **Verbindliche Arbeitsanweisung:** Abarbeitung strikt Schritt für Schritt. Einen Schritt erst nach erfolgreichem, dokumentiertem und gründlich geprüften Abschluss (inkl. Tests) als erledigt markieren.
->
-> Phasen: **Foundations (1–20)** · **Core-Gameplay (21–40)** · **System-Tiefe (41–60)** · **Monetarisierung & UX (61–80)** · **Soft-Launch & Global (81–100)**
+> **Verbindliche Arbeitsanweisung:** Schritte strikt in Reihenfolge gemäß `Zusatz.md` abarbeiten. Ein Schritt gilt erst als erledigt, wenn Ergebnis dokumentiert, getestet und mit den Leitplanken aus `Zusatz.md` abgeglichen ist.
 
----
-
-## Foundations (1–20)
-
-1. [x] **Vision & KPIs fixieren:** Zielmetriken (D1/D7/D30, ARPDAU, Crash-Rate) schriftlich festhalten.
-2. [x] **Projektstruktur anlegen:** Monorepo mit `/client` (Unity/Godot) und `/sim` (Python) + Grund-Readme.
-3. [x] **AGENTS.md & GDD übernehmen:** Dateien ins Repo legen, als „Source of Truth“ verankern.
-4. [x] **Tooling einrichten:** Poetry, pre-commit, black, ruff, mypy, pytest, nox; Basiskonfiguration prüfen.
-5. [x] **CI/CD aufsetzen:** GitHub Actions (Lint, Typing, Tests, Coverage ≥90 % Ziel), Release-Workflow skeleton.
-6. [x] **Code-Ownership & Branching:** CODEOWNERS, Conventional Commits, Branch-Namensschema.
-7. [x] **Determinismus-Kernel starten:** `rng.py` und `time.py` (Seed/Clock-Injection) inkl. Unit-Tests.
-8. [x] **GameState-Gerüst:** `state.py` (immutable Snapshots) + einfache Serialisierung.
-9. [x] **Tick-Loop & CLI:** `ki-sim run --ticks` implementieren; Smoke-Test mit Seed=42 grün.
-10. [x] **Logging-Basis:** Strukturierte Logs (Tick, Duration, Seed); Silence-Levels konfigurierbar.
-11. [x] **Config-Lader:** YAML/TOML-Loader + Pydantic-Schemas; ein Beispiel-Profil `default` bereitstellen.
-12. [x] **Ereignisbus (EventBus):** Publish/Subscribe-Grundgerüst; leere Events für spätere Systeme.
-13. [x] **Persistenz-Roundtrip:** `savegame.py` (JSON) + Test `state == load(save(state))`.
-14. [x] **Benchmark-Skeleton:** pytest-benchmark setuppen; Basis-Messung für Tick-Loop einfrieren.
-15. [x] **Client-Projekt initialisieren:** Leere Szenen/Scenes (Dashboard-Mock), Build-Pipeline lauffähig.
-16. [x] **API-Adapter (optional):** FastAPI-Stub mit `/state` (GET) → Client liest Dummy-State.
-17. [ ] **Fehlerklassen:** Domänen-Exception-Hierarchie + zentraler Handler im Sim-Kernel.
-18. [ ] **Feature-Flags:** Remote-Config-Keypfad definieren; lokale Fallbacks implementieren.
-19. [ ] **Risikoregister aufsetzen:** Top-5 Risiken + Frühindikatoren + Response-Owner.
-20. [ ] **Design-System/Styleguide:** UI-Typo, Farben, Komponentenmuster; Figma/Wireframes grob.
-
-## Core-Gameplay (21–40)
-
-21. [ ] **Projektkatalog (MVP):** Projekttyp „Chatbot“ mit Attributen (Komplexität, Daten, Reg-Level).
-22. [ ] **Qualitätsformel (MVP):** Daten/Compute/Skill/TechDebt → Qualitäts-Score + Unit-Tests.
-23. [ ] **Ökonomie-Grundlagen:** Cashflow (CAPEX/OPEX), einfache Einnahmen nach Release.
-24. [ ] **Nachfrage & Preiselastizität (MVP):** Basis-Demand + Preisfunktion; niemals Nachfrage <0.
-25. [ ] **Release-Flow (MVP):** Projektphasen (Plan→Train→Ship) + Ergebnis-Berechnung + Feedback.
-26. [ ] **Forschungspunkte (FP):** FP-Generierung aus Projekterfolg + Basisertrag pro Tick.
-27. [ ] **Tech-Tree (MVP):** 6 Knoten (Transformer-Basics, MLOps I, A/B-Suite, Bias-Monitoring, Diffusion-Intro, RL-Grundlagen) + Gates.
-28. [ ] **Team-System (MVP):** Rollen DS/ML-Eng/Backend; Skill 0–100; Gehälter; Hiring-Kosten.
-29. [ ] **Produktivität & Training:** Training ↑Skill; Crunch ↑Geschwindigkeit, ↑Burnout; Caps testen.
-30. [ ] **Ethik & Reputation (MVP):** Reputation 0–100 beeinflusst Nachfrage ± 10 %; erstes Skandal-Event.
-31. [ ] **Marketing (MVP):** Ein Kanal „PR-Push“ mit Budget→Reichweite-Kurve; Abklingzeit.
-32. [ ] **Hype-Zyklus (MVP):** Zeitbasierte Modifikatoren (Früh/Boom/Reife) wirken auf Nachfrage.
-33. [ ] **Idle-Mechanik (MVP):** Offline-Ertrag f(Δt) mit Cap 10 h; Round-Trip-Tests.
-34. [ ] **Speichersystem (Client):** Lokale Saves verschlüsselt; Sync-Stub vorbereitet.
-35. [ ] **Minispiel #1 – Parameter-Tuning:** 10–20 s Timing-Skillcheck; kleiner Qualitäts-Boost.
-36. [ ] **Tutorial v1:** Geführtes erstes Projekt inkl. Release; Telemetrie-Event „tutorial_step_*“.
-37. [ ] **Szenario-Runner:** Seeds `{1,7,42,1337}` laufen 1 In-Game-Jahr ohne Fehler.
-38. [ ] **Performance-Ziel:** `projects.simulator` ≤ 2 ms/Tick auf CI; Profiling-Bericht ablegen.
-39. [ ] **First Playable Build:** Interner Test auf 3 Geräten; Crash-Rate erheben.
-40. [ ] **Review & Adjust:** Bugs fixen, KPIs des internen Tests dokumentieren.
-
-## System-Tiefe (41–60)
-
-41. [ ] **Weitere Projekttypen:** Vision, Recommender; Balance-Parameter hinzufügen.
-42. [ ] **Produkt vs. Lizenzmodell:** API-Tiers (Free/Pro/Enterprise) + Produktverkäufe/Subscriptions.
-43. [ ] **Enterprise-Deals:** Meilenstein-Verträge mit Bonus/Penalty; Vertriebs-UI-Karten.
-44. [ ] **Preismodelle & A/B:** Zwei Preis-Kurven; Remote-Umschaltung via Feature-Flag.
-45. [ ] **Team-Erweiterung:** Designer, PM, MLOps, Ethik-Officer; Synergie-Tags (NLP/Vision/Infra).
-46. [ ] **Moral & Burnout-Dynamik:** Einflüsse (Crunch, Perks) + Regeneration; Unit-/Property-Tests.
-47. [ ] **Office-Perks:** Kantine, Weiterbildung, Sabbatical; kleine Buffs, Kosten pro Tick.
-48. [ ] **Tech-Debt-System:** Schuldenaufbau durch Crunch/Bugs; Effekte auf Qualität/Velocity.
-49. [ ] **Regulatorik-Level:** Projektattribute beeinflussen Risiko & Time-to-Market.
-50. [ ] **Ethik-Forschung vertiefen:** Bias-Monitoring, Red-Team (einmaliger Blocker/Season).
-51. [ ] **Events-Pool v1:** Datensatz-Leak, Konferenz-Preis, Audit-Hearing; Entscheidungen mit Konsequenz.
-52. [ ] **Hype-Feinheiten:** Ereignisgetriggerte Impulse; Dämpfung über Transparenzberichte.
-53. [ ] **MLOps II:** −10 % Trainingszeit global; Deploy-Stabilität ↑.
-54. [ ] **A/B-Suite Effekte:** Marketingeffizienz +8 %; Events zur Auswertung.
-55. [ ] **Diffusion/Gen-Art Projekte:** Pipeline & Asset-Kosten; neue Zielgruppen.
-56. [ ] **Speech/NLP Projekte:** ASR/TTS/NLU als Unterkategorien; Fit-Funktionen anpassen.
-57. [ ] **Healthcare-KI:** Hohe Regulatorik, höhere Margen; zusätzliche Audit-Checks.
-58. [ ] **Reputation 2.0:** Einfluss auf Bewerberqualität, Investoren-Terms; UI-Feedback.
-59. [ ] **Golden-Snapshots:** Sim-Outputs für Referenzszenarien einfrieren; CI-Drift-Checks.
-60. [ ] **Device-Farm Smoke:** 10 Gerätekonfigurationen automatisiert; Crash-Hotspots sammeln.
-
-## Monetarisierung & UX (61–80)
-
-61. [ ] **Rewarded-Ads Integration:** Adapter (ironSource/AdMob) → nur nach Missionen; Frequency Cap.
-62. [ ] **Interstitial-Ads (sparsam):** Nach großen Releases; Skip/No-Ads-Guardrail prüfen.
-63. [ ] **IAP-Katalog:** Compute-Credits (5 Preis-Stufen), No-Ads, QoL-Pass; Store-Sandbox testen.
-64. [ ] **Kosmetik-System:** Office-Skins, Charakter-Outfits, UI-Themes; keinerlei Gameplay-Vorteile.
-65. [ ] **QoL-Funktionen:** Extra-Save-Slots, Automations-Queue; nur Komfort, keine Progression.
-66. [ ] **Cloud-Sync:** Platform-SDKs (GPGS/iCloud) + Konfliktlösung (neuester vollständiger Fortschritt).
-67. [ ] **Crash-Reporting:** Crashlytics/Sentry integrieren; DSN/PII-Filter aktiv.
-68. [ ] **Datenschutz & GDPR:** Opt-in-Dialoge, Tracking-Toggles, „Daten löschen“ im Client.
-69. [ ] **Barrierefreiheit:** Skalierbare Schrift, Farbmodi, reduzierte Animationen.
-70. [ ] **UI-Polish Pass:** Micro-Interaktionen, Haptik, Ladezeiten; NPS-Fragen nach 5 Sitzungen.
-71. [ ] **Minispiel #2 – Bug-Hunt:** Muster erkennen → Tech-Debt −x; 20 s, skill-basiert.
-72. [ ] **Minispiel #3 – Pitch-Deck:** Kartenwahl → bessere Investor-Terms bei Erfolg.
-73. [ ] **Tutorial v2:** Kürzer, entscheidungsreich; Abbruchstellen aus Telemetrie geschlossen.
-74. [ ] **Live-Ops Grundgerüst:** Wöchentliche Challenge (Seed-Preset), Leaderboard (Client-seitig fair).
-75. [ ] **Analytics-Dashboards:** D1/D7, FTUE-Funnel, ARPDAU, Ad-Fill; Looker/Metabase einrichten.
-76. [ ] **A/B-Framework:** Variant-Zuweisung, Guardrails, Auswertung nach Kohorten.
-77. [ ] **Remote-Config Live:** Preise, Idle-Cap, Ad-Frequenzen live steuerbar.
-78. [ ] **Lokalisierung EN/DE:** String-Externalisierung, Kontext-Screens, QA.
-79. [ ] **Store-Assets v1:** 6 Screens, 30 s Trailer-Skript, ASO-Keywords.
-80. [ ] **Pressekit & Community:** Website/Discord, FAQ, devlog-Post vorbereiten.
-
-## Soft-Launch & Global (81–100)
-
-81. [ ] **Content Season 0 komplettieren:** 3–4 Projekttypen, kleiner Tech-Tree, Events-Mix.
-82. [ ] **Soft-Launch-Märkte wählen:** CAN/NZ/Skandinavien; Pricing & Ads konservativ.
-83. [ ] **Build-Qualifizierung:** Stability ≥ 99,7 %, Crash-Top-3 gefixt, Cold-Start < 3 s.
-84. [ ] **Submission & Review:** Store-Compliance prüfen (Privacy, Ads, Zahlungen, Jugendschutz 12+).
-85. [ ] **Soft-Launch Live (T-0):** Monitoring 24/48/72 h; War-Room-Runbook bereit.
-86. [ ] **FTUE-Optimierung (Woche 1):** Tutorial-Abbrüche fixen; D1-Hebel testen.
-87. [ ] **Ökonomie-Feintuning (Woche 2):** Nachfrage/Preis-Kurven kalibrieren; Bottlenecks lösen.
-88. [ ] **Ads-Tuning (Woche 3):** Frequency Caps/Placements A/B; No-Ads-Conversion tracken.
-89. [ ] **IAP-Preisleiter (Woche 3):** Anker/Bundle-Tests; Refund-Flow prüfen.
-90. [ ] **Retention-Layer (Woche 4):** Daily-Quests & Login-Serie (rein kosmetische Rewards).
-91. [ ] **Season-Roadmap ankündigen:** S1-Teaser (Gen-Art/Speech), Transparenz zu Fairness.
-92. [ ] **Kohorten-Analyse (Woche 5):** D7/D30 & ARPDAU gegen Ziele; Go/No-Go-Gate.
-93. [ ] **Lokalisierung v2:** Zusätzliche Sprachen (ES/FR) abhängig vom Potenzial.
-94. [ ] **Skalierung Backends:** Ad-Mediation/Analytics Quoten, API-Raten, CDN-Assets prüfen.
-95. [ ] **Security-Pass:** Dependency-Audit, Pen-Test-Checkliste, Secrets-Rotation.
-96. [ ] **Global-Launch-Checkliste:** Store-Texte final, Trailer, Influencer-Slots, UTM-Links.
-97. [ ] **Global Launch (T-0):** Staged Rollout 10%→50%→100%; Monitoring & Hotfix-Pfad.
-98. [ ] **Post-Launch Patch 1:** Crash/Balance-Fixes, QoL aus Feedback; Notizen veröffentlichen.
-99. [ ] **Season 1 Release:** Neue Projekte (Gen-Art/Speech), Forschung (RL-Grundlagen), Event „Konferenz-Expo“.
-100. [ ] **Roadmap H2 & Team-Scaling:** Neue Hiring-Slots, Produktionskalender, Quartals-OKRs festlegen.
+Phasen: **Preflight (1–10)** · **W1 – Projekt & Kernel (11–25)** · **W2 – Daten & Ökonomie (26–40)** · **W3 – UI First Pass (41–55)** · **W4 – Steam & Content (56–70)** · **W5 – Polish & Beta (71–85)** · **W6 – Release (86–95)** · **Post-Launch (96–100)**
 
 ---
 
-**Abnahme-Kriterium je Schritt:** „Messbarer Artefakt-Nachweis“ (PR, Build, Dashboard, Testbericht). Erledigte Schritte dokumentieren inklusive Verweis auf die bestandenen Tests.
+## Preflight & Governance (1–10)
+
+1. [ ] Budget-Obergrenze (≤ €500) bestätigen, Ausgaben-Tracker anlegen.
+2. [ ] Steam-Account-Status prüfen (Partner-Programm aktiv, Zahlungsdaten hinterlegt).
+3. [ ] Unity 6 LTS (6000.x) via Hub installieren; Projekteinstellungen für Windows x64 vorbereiten.
+4. [ ] Repository-Setup überprüfen: `Zusatz.md` als Source of Truth referenzieren, Legacy-Dokumente kennzeichnen.
+5. [ ] Tooling-Stack festlegen (Rider/VS, Git, Git LFS falls nötig, Art-Tools, Audio-Tools) – ausschließlich kostenfrei.
+6. [ ] Naming- und Namespace-Konventionen definieren (`Core.Sim`, `Game.App`, `Game.UI`, `Platform.Steam`).
+7. [ ] Issue-/Task-Board für W1–W6 anlegen; Checkpoints aus `Zusatz.md` übertragen.
+8. [ ] Architektur-Risiken erfassen (Determinismus, Save-Migration, Steamworks) und Mitigations notieren.
+9. [ ] Test-Strategie definieren (Unit, Property, Headless-Runner, KPI-CSV) inkl. Seed-Plan.
+10. [ ] Release-Kalender mit Meilensteinen und Deadlines (W1–W6) veröffentlichen.
+
+---
+
+## W1 — Projekt & Kernel (11–25)
+
+11. [ ] Unity-Projekt `ai-dev-tycoon` erstellen (2D Core Template, URP deaktivieren).
+12. [ ] Basis-Ordnerstruktur laut `Zusatz.md` anlegen (`Scripts/Core.Sim` etc.).
+13. [ ] Steamworks.NET via UPM Git einbinden; `steam_appid.txt` konfigurieren.
+14. [ ] Bootstrap-Szene mit GameLoop-Script und SteamManager-Placeholder erstellen.
+15. [ ] Interfaces `ITimeProvider` und `IRng` implementieren (inkl. PCG32-Tests in C#).
+16. [ ] Deterministischen Tick-Loop (0,5 s) implementieren und Unit-Test (Mock-Sim) hinzufügen.
+17. [ ] Domain-Grundgerüst `Sim` mit Tick-Dispatch und Event-Publisher anlegen.
+18. [ ] Save/Load-Schnittstelle `SaveIO` (JSON + GZip) implementieren, inklusive Pfad-Resolver.
+19. [ ] Rotation von 3 Save-Slots (Slot-Metadaten + Autosave) definieren.
+20. [ ] Dependency-Injection für Sim/Time/RNG in Bootstrap verkabeln (ScriptableInstaller oder eigenes Setup).
+21. [ ] Logging/Diagnostics in Editor-Modus aktivieren (Console + optional Textfile im Dev-Build).
+22. [ ] Erste Play-Mode-Tests (EditMode/PlayMode) für Tick & Save ausführen.
+23. [ ] Continuous-Integration-Check vorbereiten (lokaler Build + Test-Script).
+24. [ ] Dokumentation der Kernel-APIs (XML Comments + `docs/`-Kurzübersicht) verfassen.
+25. [ ] Abschluss-W1-Review: Tick-Loop, RNG, Save, Steam-Bootstrap manuell testen und Notizen sammeln.
+
+---
+
+## W2 — Daten & Ökonomie (26–40)
+
+26. [ ] ScriptableObject-Basis `RoleDef`, `ResearchNodeDef`, `ProductDef`, `MarketSegmentDef`, `EventDef` anlegen.
+27. [ ] Editor-Inspector anpassen (Custom Editors) für bessere Dateneingabe.
+28. [ ] Start-Datenbestand erstellen: 5 Rollen, 3 Marktsegmente, 1 Produkt, Basis-Event-Pool.
+29. [ ] Wirtschaftliche Konstanten definieren (Start-Cash, laufende Kosten, Kapazitätsgrenzen).
+30. [ ] Forschungssystem: Forschungsqueue, Fortschrittsberechnung pro Tick implementieren.
+31. [ ] Hiring-System: Kandidaten-Generator (Poisson/Normal) mit RNG-Stream `hiring` umsetzen.
+32. [ ] Training/Skill-Progression pro Tick implementieren (inkl. Burnout-Tracking).
+33. [ ] Produkt-Qualitätsformel aus `Zusatz.md` implementieren (tanh + log Datenmenge).
+34. [ ] Adoption/Revenue-Modelle (S-Kurve, Preis-Anpassung) in Sim-Kernel integrieren.
+35. [ ] Ereignissystem: Weighted-Random-Picker mit Multiplikator-Effekten (Events-Stream) realisieren.
+36. [ ] Offline-Progress-Funktion implementieren (analytische Auswertung vs. Tick-Schleife).
+37. [ ] Save-Game-Serialisierung für neue Module (Team, Forschung, Produkte, Economy) ergänzen.
+38. [ ] Property-Tests/Unit-Tests für Invarianten (Quality ∈ [0,1], Cash ≥ 0 ohne Kredit, Adoption ≤ TAM) schreiben.
+39. [ ] Headless-Batchrunner (CLI) erstellen, der 30 Ingame-Tage simuliert und KPI-CSV exportiert.
+40. [ ] Abschluss-W2-Review: Balancing-Outputs prüfen, Budget-Impact dokumentieren.
+
+---
+
+## W3 — UI First Pass (41–55)
+
+41. [ ] UI-Foundation: Canvas + EventSystem einrichten, Responsive Layout (16:9) konfigurieren.
+42. [ ] Bottom-Navbar mit 5 Tabs (HQ, Team, Forschung, Produkte, Markt) layouten.
+43. [ ] HQ-Dashboard-Greybox (Cash, Burn, Reputation, aktive Projekte, Events-Ticker) erstellen.
+44. [ ] Team-Ansicht: Liste der Mitarbeitenden, Bewerbungsbatch, Hiring-Dialog (Dummy-Daten) aufbauen.
+45. [ ] Forschungs-Screen: Tech-Tree-Visualisierung (Tier-Gruppen, Tooltips) prototypen.
+46. [ ] Produkt-Screen: Blueprint→Launch-Flow, Qualitäts-KPI, Pricing-Slider abbilden.
+47. [ ] Markt-Screen: Segmente, TAM, Preis-/Qualitäts-Fit, Hype-Indikator darstellen.
+48. [ ] Events/Log-Screen: Chronologische Liste mit Tooltip-Effekten und Dauer.
+49. [ ] UI-Presenter-Schicht (MVP-Pattern) erstellen, Domain-Events abonnieren.
+50. [ ] Tooltips & Hover-States implementieren; Accessibility-Schalter (Animation reduzieren) ergänzen.
+51. [ ] TextMeshPro-Styling nach Styleguide (Rubik/Inter, Farbpalette aus `Zusatz.md`).
+52. [ ] Erste Icon-/Illustrations-Pass (CC0-Assets) integrieren, Placeholder markieren.
+53. [ ] Navigation & Zustandsspeicherung testen (Tab-Wechsel, Modal-Dialoge).
+54. [ ] Lokalisierungspipeline vorbereiten (Unity Localization, String-Tables EN/DE).
+55. [ ] Abschluss-W3-Review: UX-Notizen sammeln, Performance-Check im Editor (FrameTime ≤ 16 ms).
+
+---
+
+## W4 — Steam & Content (56–70)
+
+56. [ ] Steamworks-Initialisierung finalisieren (Overlay, Callback-Handling, Shutdown-Safety).
+57. [ ] Achievement-System `Ach.Unlock` mit Domain-Events verknüpfen.
+58. [ ] Startliste Achievements (8–12) final definieren und in Steamworks eintragen.
+59. [ ] Rich Presence Strings entwerfen und im Steam-Adapter implementieren.
+60. [ ] Savegame-Versionierung (`version`, Migrations-Interface) einführen.
+61. [ ] ContentBuilder-Ordnerstruktur vorbereiten (`app_build_<appid>.vdf`).
+62. [ ] Automatisiertes Build-Script (Batch/PowerShell) für Headless Windows-Build erstellen.
+63. [ ] Erste Windows-IL2CPP-Builds testen (manuell starten, Steam-Overlay prüfen).
+64. [ ] Trailer-Capture-Plan erstellen (Shot-Liste, Timeline 30–45 s).
+65. [ ] Screenshot-Set (6 Stück) aufnehmen, UI aufräumen.
+66. [ ] Store-Text (EN/DE) entwerfen: Short-Description, Long-Description, Feature-Bullets.
+67. [ ] Capsule-Art V1 (Header, Library, Hero) gestalten oder aus Asset-Template ableiten.
+68. [ ] Presskit-/Marketing-Ordner im Repo anlegen (Screens, Logos, Beschreibung).
+69. [ ] QA-Pass: Achievements, Rich Presence, Save/Load Rotation, Offline-Cap testen.
+70. [ ] Abschluss-W4-Review: Steam-Checklist abgleichen, Feedback loggen.
+
+---
+
+## W5 — Polish & Beta (71–85)
+
+71. [ ] Balancing-Pass durchführen (Einnahmen, Kosten, Reputation-Drift) anhand Headless-Daten.
+72. [ ] Performance-Profiling (Unity Profiler) auf Problemstellen prüfen (CPU/GPU, GC).
+73. [ ] UI-Polish: Animationen (LeanTween), Hover/Press-Feedback, Achievement-Toast.
+74. [ ] Audio-Pass: UI-Foleys, Münz-SFX, Lautstärke-Balancing, Audio-Toggle.
+75. [ ] Accessibility-Review: Farbkontrast ≥ 4.5:1 validieren, Focus-Outlines setzen.
+76. [ ] Bugfix-Sprint: Kritische Bugs aus QA-Liste beheben.
+77. [ ] Beta-Build intern verteilen (Freundeskreis/Closed Group), Feedback-Formular bereitstellen.
+78. [ ] Feedback auswerten, Backlog priorisieren (Must-Fix vs. Post-Launch).
+79. [ ] Lokalisierung DE finalisieren, QA-Lauf (Proofread, Layout-Anpassung).
+80. [ ] Savegame-Migrationstest (v1 → v1) durchführen, Vorbereitung auf v2 skizzieren.
+81. [ ] Automatisierte Tests erweitern (zusätzliche Property-Checks, Regression Seeds).
+82. [ ] Crash- und Exception-Logging (Unity Cloud Diagnostics optional deaktiviert) lokal prüfen.
+83. [ ] Finaler Code-Review (Self-Review + Checkliste) durchführen.
+84. [ ] Release-Notizen (Changelog v0.1.0) schreiben.
+85. [ ] Abschluss-W5-Review: Beta-Feedback, Restaufgaben, Launch-Go/No-Go bestätigen.
+
+---
+
+## W6 — Release (86–95)
+
+86. [ ] Finalen Release-Build (IL2CPP) erzeugen, Smoke-Test durchführen.
+87. [ ] Steam Depots hochladen (ContentBuilder), Build genehmigen lassen.
+88. [ ] Preis €5.99 im Steam-Backend setzen, Steuern prüfen.
+89. [ ] Altersfreigaben & rechtliche Hinweise (GDPR, Datenschutzhinweis) bestätigen.
+90. [ ] Store-Seite veröffentlichen, sichtbare QA (Screens, Text, Tags) final checken.
+91. [ ] Kommunikations-Post (Devlog/Steam News) vorbereiten.
+92. [ ] Launch-Day-Runbook (Zeitplan, Checkliste, Support-Kanäle) dokumentieren.
+93. [ ] Letzter QA-Pass: Achievements, Save/Load, Offline-Progress, Performance.
+94. [ ] Launch durchführen, Status auf allen Kanälen (Website, Social) teilen.
+95. [ ] Hotfix-Pfad definieren (Branching, Patch-Build-Schritte).
+
+---
+
+## Post-Launch Monitoring (96–100)
+
+96. [ ] Wishlist→Sale-, Refund-, Review-Daten in den ersten 48 Stunden monitoren und protokollieren.
+97. [ ] Crash-Rate prüfen (Steam-Backoffice, Spieler:innen-Feedback) und Issues priorisieren.
+98. [ ] Gate A bewerten (Umsatz ≥ €1.000?) und Early-Access-Roadmap ableiten.
+99. [ ] Gate B prüfen (CR < 5 % oder Reviews < 80 %?) und Balancing/UX-Plan definieren.
+100. [ ] Post-Mortem v0.1.0 verfassen (Was lief gut/schlecht, nächste Schritte) und mit `Zusatz.md` abgleichen.
+

--- a/Gameplan.md
+++ b/Gameplan.md
@@ -1,6 +1,8 @@
 # KI‑Dev‑Tycoon — Produktions‑ & Game‑Design‑Plan (GDD/PRD)
 
-> **Ziel:** Vollständig ausgearbeiteter Plan für ein mobile‑fokussiertes Tycoon‑Spiel, das den Aufbau eines KI‑Unternehmens simuliert. Optimiert für kurze Sessions (5–10 Minuten), langlebige Progression, ethische Entscheidungen und Free‑to‑Play‑Monetarisierung ohne Pay‑to‑Win.
+> **Einordnung:** Dieses Dokument ergänzt [`Zusatz.md`](./Zusatz.md) und vertieft die dort definierten Leitplanken für den Steam‑MVP (Windows x64, offline, Solo‑Dev, Budget ≤ €500). Alle Angaben folgen der Paid‑Upfront‑Strategie (€5.99) ohne Online‑Pflicht.
+
+> **Ziel:** Vollständig ausgearbeiteter Plan für einen Desktop‑Tycoon, der den Aufbau eines KI‑Unternehmens simuliert. Optimiert für kurze bis mittlere Sessions (5–20 Minuten), langlebige Meta‑Progression, ethische Entscheidungen und faire Monetarisierung ohne Live‑Ops‑Abhängigkeiten.
 
 ---
 
@@ -14,16 +16,16 @@
 * Schnelle Sessions (Idle + Minispiele für Tuning), tiefe Meta‑Progression (Tech‑Tree, Reputation, Team‑Synergien).
 * „Ethik & Reputation“ als echter Gameplay‑Hebel, nicht nur Flavor.
 
-**Kern‑KPIs (Soft‑Launch‑Ziele):** D1 ≥ 35 %, D7 ≥ 12 %, D30 ≥ 4 %, ARPDAU ≥ 0,08 €, Ad‑Fill ≥ 90 %, Crash‑Rate ≤ 0,3 %.
+**Kern‑KPIs (Launch + 2 Wochen):** Wishlist→Sale CR ≥ 10 %, Refund‑Rate ≤ 8 %, ≥ 75 % positive Steam‑Reviews (n≥20), Crash‑Rate ≤ 0,3 %.
 
 ---
 
 ## 2) Zielgruppe & Plattformen
 
-* **Plattformen:** iOS & Android (Portrait).
-* **Zielgruppe:** 16–45, Tech‑affin, Casual‑bis‑Midcore‑Tycoon‑Spieler.
-* **Sitzungs‑Design:** 5–10 Minuten; Idle‑Erträge bei Abwesenheit (8–12 Stunden Cap).
-* **Barrierefreiheit:** An-/Abschaltbare Animationen, Farbblind‑Modus, skalierbare UI‑Schrift.
+* **Plattform (Launch):** Windows x64 (Steam, 16:9, Maus/Keyboard). Steam‑Deck wird als „Should“-Have getestet.
+* **Zielgruppe:** 16–45, Tech‑affin, Casual‑bis‑Midcore‑Tycoon‑Spieler:innen mit Interesse an KI‑Trends.
+* **Sitzungs‑Design:** 5–20 Minuten; Offline‑Simulation verarbeitet Abwesenheit bis ca. 12 Stunden.
+* **Barrierefreiheit:** Skalierbare UI‑Schrift (90–120 %), farbenblind‑sichere Palette, reduzierbare Animationen.
 
 ---
 
@@ -31,11 +33,11 @@
 
 ### 3.1 Core Loop
 
-1. **Projektwahl** (Thema × Zielgruppe × Plattform).
+1. **Projektwahl** (Thema × Segment × Plattform).
 2. **Ressourcen zuweisen** (Daten, Compute, Teamzeit).
-3. **Training/Entwicklung** (Idle‑Timer + Minispiele).
-4. **Release** (Produkt oder API/Lizenz) → Einnahmen + Feedback.
-5. **Reinvest** (Forschung, Team, Marketing, Infrastruktur).
+3. **Training/Entwicklung** (0,5 s Tick‑Loop + optionale Minispiele).
+4. **Release** (Produkt oder API/Lizenz) → Einnahmen + Feedback, Steam‑Achievement‑Hooks.
+5. **Reinvest** (Forschung, Team, Marketing, Infrastruktur) → Vorbereitung auf nächste Ära.
 
 ### 3.2 Meta Loop
 
@@ -46,9 +48,9 @@
 
 ### 3.3 Zeitleisten/Hypes
 
-* **Frühphase:** Klassische ML‑Aufgaben, knappe Mittel.
-* **Boom:** Cloud & Deep Learning, Venture Deals, schnelleres Wachstum.
-* **Reife:** Generative KI, Robotik, Regulierung, hohe Skalierungskosten.
+* **Frühphase:** Klassische ML‑Aufgaben, knappe Mittel, Fokus auf Break‑Even.
+* **Boom:** Cloud & Deep Learning, gesteigerte Nachfrage, Steam‑Achievement „First 1k“.
+* **Reife:** Generative KI, Regulierung, hohe Skalierungskosten, Risiken durch Events.
 
 ---
 
@@ -56,7 +58,7 @@
 
 ### 4.1 Projekte & Markt‑Fit
 
-* **Projekttypen:** Chatbot, Vision, Empfehlung, Gen‑Art, AV‑Module, Healthcare‑KI, Fin‑KI, Quanten‑KI‑Prototypen (spät).
+* **Projekttypen:** Chatbot, Vision, Empfehlung, Gen‑Art, AV‑Module, Healthcare‑KI, Fin‑KI, Quanten‑Prototypen (spät).
 * **Attribute:** Thema, Zielgruppe, Komplexität, Datenbedarf, Regulatorik‑Level, Time‑to‑Market, Risiko.
 * **Erfolgsformel (vereinfacht):**
 
@@ -68,13 +70,13 @@ Nachfrage    = BaseDemand * g(Preis, Konkurrenz) * RegulatorikCap
 
 ### 4.2 Forschung (Tech‑Tree)
 
-* **Kategorien:** Algorithmen (Transformer, RL, GNN), Anwendungen (Healthcare, Fin, NLP), Toolchain (MLOps, A/B‑Suite), Ethik (Bias‑Monitoring), Infrastruktur (GPU‑Cluster, Edge).
-* **Freischaltung:** Forschungspunkte (FP) aus Projekterfolg + Basisertrag pro Tick.
-* **Gates:** Abhängigkeiten + Zeitalter; Ethik‑Knoten reduzieren Skandalsrisiko global.
+* **Kategorien:** Algorithmen (Transformer, RL, GNN), Anwendungen (Healthcare, Fin, NLP), Toolchain (MLOps, Experimentation), Ethik (Bias‑Monitoring), Infrastruktur (GPU‑Cluster, Edge).
+* **Freischaltung:** Forschungspunkte (FP) aus Projekterfolg + Basisertrag pro Tick; Speed durch Mitarbeiter‑Skills.
+* **Gates:** Abhängigkeiten + Ära; Ethik‑Knoten reduzieren Skandalsrisiko global (Steam‑Achievement „Tier‑2 Unlocked“).
 
 ### 4.3 Team & Produktivität
 
-* **Rollen:** Data Scientist, ML‑Engineer, Backend, MLOps, Designer, PM, Ethik‑Officer.
+* **Rollen:** Data Scientist, ML‑Engineer, Backend, MLOps, Designer, PM, Ethik‑Officer (ScriptableObject‑Definitions gemäß `Zusatz.md`).
 * **Werte:** Skill (0–100), Synergie‑Tags (NLP/Vision/Infra), Moral, Burnout, Gehalt.
 * **Mechaniken:** Training ↑Skill; Crunch ↑Speed aber ↑Burnout; Diversität ↓Bias‑Risiko leicht.
 * **Office‑Perks:** Kantine, Weiterbildung, Sabbaticals → Moral‑Buffs.
@@ -93,208 +95,140 @@ Nachfrage    = BaseDemand * g(Preis, Konkurrenz) * RegulatorikCap
 * **Produkt vs. Lizenz:** Produkt = höhere Margin, volatil; Lizenz = planbar, gedeckelt.
 * **Cash‑Flow‑Regeln:** Keine negativen Kontostände jenseits Kreditlinie; Zinsen ab Schwelle.
 
-### 4.6 Marketing & Trends
+### 4.6 Go-to-Market & Trends
 
-* **Kanäle:** PR, Content, Ads, Konferenzen, Thought Leadership.
-* **Modell:** Reichweite ~ Budget^δ * Kreativitäts‑Multiplikator; PR profitiert von Reputation.
-* **Hype‑Impulse:** Zeitgesteuerte Multiplikatoren; Gegenmaßnahmen via Ethik/Transparenz.
+* **Kanäle:** Steam Discovery Queue, Devlog-Posts, Fachpresse (Tech/AI), Influencer-Streams, Wishlist-Kampagnen.
+* **Modell:** Fokus auf Wishlists → Conversion am Launch-Tag; Reputation steigert PR-Reichweite.
+* **Hype-Impulse:** Zeitalter-abhängige Nachfrage-Boosts; Ethik-/Transparenz-Investitionen dämpfen Negativtrends.
 
-### 4.7 Minispiele (kurz & skill‑basiert)
+### 4.7 Minispiele (kurz & skill-basiert)
 
-* **Parameter‑Tuning:** „Lock‑in“ Bonus‑Perks durch kurze Zielwerte (Timing/Slider).
-* **Bug‑Hunt:** Muster finden → reduziert Tech‑Debt.
-* **Pitch‑Deck:** Kartenwahl für Investor‑Meetings → bessere Terms bei Erfolg.
+* **Parameter-Tuning:** „Lock-in“ Bonus-Perks durch Timing/Slider (optional, offline spielbar).
+* **Bug-Hunt:** Muster finden → reduziert Tech-Debt, triggert Steam-Toasts.
+* **Pitch-Deck:** Kartenwahl für Investor-Meetings → bessere Terms bei Erfolg.
 
-### 4.8 Idle‑Mechanik
+### 4.8 Idle-Mechanik
 
-* **Offline‑Berechnung:**
-
-```
-Ertrag_offline = min(Cap, f(Aktive Pipelines, Subscriptions, API‑Traffic))
-Diminishing Returns nach 8–12h; täglicher Login‑Boost (einmalig)
-```
+* **Offline-Berechnung:** 0,5 s Fixed-Tick; Offline-Cap 8–12 h; analytische Formeln für große Δt (siehe `Zusatz.md`).
 
 ---
 
-## 5) Content‑Plan (Season 0 → 2)
+## 5) Milestone-Roadmap (W1–W6)
 
-| Season      | Ära/Schwerpunkt     | Neue Projekte                | Forschung                       | Events                          | Ziel                     |
-| ----------- | ------------------- | ---------------------------- | ------------------------------- | ------------------------------- | ------------------------ |
-| S0 (Launch) | Frühphase           | Chatbot, Vision, Recommender | Transformer‑Basics, MLOps I     | KI‑Winter‑Rückblick, PR‑Skandal | Onboarding, Retention    |
-| S1          | Boom (Cloud/DL)     | Gen‑Art, Speech              | RL‑Grundlagen, A/B‑Suite        | Konferenz‑Expo, Audit           | Monetarisierung/Live‑Ops |
-| S2          | Reife (Gen‑KI/Reg.) | AV‑Module, Healthcare        | Bias‑Monitoring, Red‑Team, Edge | Regulierungspaket, Leak         | Tiefe/Metagame           |
-
----
-
-## 6) Monetarisierung (F2P, fair)
-
-* **Ads:** Rewarded Video (Speed‑Boost, Soft‑Währung), Interstitials nur nach Missionen (Frequency Cap: 1/5 Min, max 4/Tag).
-* **IAP:**
-
-  * **Premium‑Währung:** „Compute‑Credits“ (z. B. 1,99 € bis 49,99 €).
-  * **Kosmetik:** Office‑Skins, Charakter‑Outfits, Themen‑UIs.
-  * **QoL‑Pässe:** Zusätzliche Save‑Slots, Automations‑Queue.
-* **Einmalkauf (No‑Ads):** 6,99–9,99 €, + Szenario „KI in der Medizin“.
-* **Fairness‑Guardrails:** Keine Pay‑Gates bei Kernprogression; Monetarisierung beschleunigt, ersetzt nicht.
+| Woche | Fokus                | Kernlieferobjekte                                          |
+| ----- | -------------------- | ---------------------------------------------------------- |
+| W1    | Projekt & Kernel     | Unity-Projekt, Tick-Loop, RNG, Save/Load, Steam-Bootstrap  |
+| W2    | Daten & Ökonomie     | ScriptableObjects, Hiring/Forschung/Ökonomie, Offline-Cap  |
+| W3    | UI First Pass        | Greybox aller Screens, Presenter, Localization-Setup       |
+| W4    | Steam & Content      | Achievements, Rich Presence, Screenshots, Store-Texte      |
+| W5    | Polish & Beta        | Balancing, Profiling, Audio, Accessibility, Beta-Feedback  |
+| W6    | Release              | Finaler Build, Store-Go-Live, Kommunikation, Hotfix-Pfad   |
 
 ---
 
-## 7) UX/UI‑Leitlinien
+## 6) Monetarisierung (Paid Upfront)
 
-* **Main Screens:** HQ‑Dashboard → Projekte → Forschung → Team → Markt → Ethik.
-* **Informationsdichte:** Karten‑Layout, Tooltips, kontextuelle Glossare.
-* **Tutorial (≤ 6 Min):** 1) Erstes Projekt 2) Training & Release 3) Forschungspunkte 4) Teamhire 5) Ethik‑Entscheidung 6) Marketing.
-* **Benachrichtigungen:** Sanft, bündelbar, stille Nachtzeiten.
+- **Preis:** €5.99 einmalig, keine Rabatte zum Launch (Wishlist-Konversion messen).
+- **Keine Ads/IAPs:** Monetarisierung erfolgt ausschließlich über den Kaufpreis.
+- **Value-Kommunikation:** „Solo-Dev, deterministische KI-Unternehmenssimulation“ + Transparenz über Updates.
+- **Achievements & Extras:** 8–12 Achievements als Mehrwert, optionale Demo (itch.io) zur Wishlist-Generierung.
+
+---
+
+## 7) UX/UI-Leitlinien
+
+- **Main Screens:** HQ-Dashboard → Projekte → Forschung → Team → Markt → Events.
+- **Informationsdichte:** Karten-Layout, Tooltips, Glossare; Controller-Support optional spätere Erweiterung.
+- **Onboarding (≤ 10 Min):** Erstes Projekt abschließen, Forschung freischalten, Hiring durchführen, Preis anpassen.
+- **Notifications:** In-Game Log & Toasts, keine Pushes; Fokus-Modus (reduzierte Animationen) optional.
 
 ---
 
 ## 8) Technik & Architektur
 
-* **Client:** Unity (C#) oder Godot (GDScript/C#), Mobile Portrait, Addressables/AssetBundles, lokal verschlüsselter Save.
-* **Sim‑Kernel (optional getrennt):** Python (siehe AGENTS.md), deterministisch, API via FastAPI/HTTP oder eingebettete Lib.
-* **Offline‑Support:** Delta‑Zeit‑Berechnung, Konfliktlösung bei Cloud‑Sync.
-* **Analytics:** Client‑Events → Backend (Batch), Remote Config/Feature‑Flags.
-* **Build‑Pipeline:** CI (GitHub Actions), Testgerätefarm, Symbol‑Upload (Crashlytics/Sentry).
+- **Client:** Unity 6 LTS, Windows x64, IL2CPP Release, Addressables lokal.
+- **Sim-Kernel:** Reines C# (`Core.Sim`), deterministisch, keine Unity-Abhängigkeiten; Python-Kernel dient als Test-Harness.
+- **Persistenz:** JSON + GZip, Versionierung mit `ISaveMigrator`.
+- **Automation:** Lokale CI (nox/pytest für Python, Unity Batchmode für Builds), kein externer Backend-Service.
 
-**Datenstruktur (Savegame, vereinfacht):**
+**Savegame (MVP):**
 
 ```json
 {
-  "version": 5,
-  "tick": 12345,
-  "rng_seed": 42,
-  "cash": 125000,
-  "reputation": 67,
-  "projects": [...],
-  "research": {"unlocked": ["transformer_basic"], "fp": 12},
-  "team": [...],
-  "market": {"hype": 0.2},
-  "ethics": {"risk": 0.08, "invest": 2}
+  "version": 1,
+  "seed": 9201531,
+  "last_time": "2025-10-06T10:00:00Z",
+  "company": {"cash": 20000, "reputation": 0.0},
+  "employees": {...},
+  "research": {...},
+  "products": {...},
+  "rng_stream": {"hiring": 12345, "events": 777}
 }
 ```
 
 ---
 
-## 9) Analytics & A/B‑Testing
+## 9) Telemetrie & Messung
 
-**Kern‑Events:** `session_start`, `tutorial_step`, `project_start/release`, `fp_gain/spend`, `ethics_event`, `reputation_change`, `ad_watch`, `iap_purchase`, `churn_flag`, `returning_user`.
-
-**Funnel‑Metriken:** Install → Tutorial Complete → Erstes Release → Forschung Spend → 24h Retention → Monetarisierungs‑Kontakt.
-**Experimente (Beispiele):** Tutorial‑Reihenfolge A/B, Rewarded‑Placement, Idle‑Cap 8 vs. 12 Std, Preisanker für IAP.
-
----
-
-## 10) Balancing‑Modell (Formeln & Parameter)
-
-**Qualität:**
-$$\text{Qualität} = k_0 + k_1\log(1+\text{Daten}) + k_2\log(1+\text{Compute}) + k_3\cdot \text{TeamSkill} - \text{TechDebt}$$
-
-**Nachfrage:**
-$$\text{Nachfrage} = B\cdot \text{Fit}(t,z)\cdot (1+H)\cdot (1+\rho/100)\cdot e^{-\lambda,Preis}$$
-
-**Skandal‑Risiko:**
-$$p_{skandal}=p_0\cdot (1-\text{EthikInvest})\cdot (1-\text{Diversität})\cdot (1+H)$$
-
-**Idle‑Ertrag:**
-$$E_{offline}=\min(Cap,; E_{tick}\cdot f(\Delta t))\quad,; f(\Delta t)=1- e^{-\mu,\Delta t}$$
-
-**Start‑Parameter (vorschlagen, Feintuning in Beta):**
-
-* (k_1=0.8, k_2=0.6, k_3=0.02, \lambda=0.15, \mu=0.12), Idle‑Cap = 10 h, HypeMod im Boom = +30 %.
+- **Kein Online-Tracking:** Keine externen Analytics oder Remote Config im MVP.
+- **Lokale Logs:** Optionale CSV-Exports für Tests, Debug-Konsole im Dev-Build.
+- **Business-Metriken:** Steam Backoffice (Sales, Refunds, Reviews) + manuelle KPI-Sheets.
 
 ---
 
-## 11) Live‑Ops & Community
+## 10) Balancing-Modell (Formeln & Parameter)
 
-* **Wöchentliche Challenges:** „Bestes Gen‑Art‑Modell“ (Seeds & Parameter vorgegeben).
-* **Monatliche Events:** Szenario‑Runs mit Leaderboard (fair, ohne P2W).
-* **Koop‑Projekte:** Gilde‑ähnliche Forschungspools (nur kosmetische Rewards).
-* **UGC‑Leichtgewicht:** Presets teilen (keine externen Daten).
+- **Qualität:** `quality = tanh(a*modelQuality + b*ln(dataQty+1) + c*infraCap)`
+- **Nachfrage:** `BaseDemand * fit(price, quality) * (1 + hype) * (1 + reputation/100)`
+- **Skandal-Risiko:** `p = base * (1 - ethicsInvest) * (1 - diversity) * (1 + hype)`
+- **Offline-Ertrag:** `min(cap, tickIncome * f(Δt))`, mit `f(Δt) = 1 - exp(-μ*Δt)`
+- **Startparameter:** `a=0.9`, `b=0.7`, `c=0.15`, `μ=0.12`, Offline-Cap = 10 h, Boom-Hype = +30 %.
 
 ---
 
-## 12) Produktionsplan (18 Wochen Soft‑Launch)
+## 11) Post-Launch Outlook
 
-**Team (Kern, FTE‑Äquivalente):** 1 Producer, 2 Gameplay, 1 Client‑UI, 1 Backend/Sim, 1 Designer, 0.5 Artist, 0.5 QA, 0.5 Data/Live‑Ops.
+- **Kostenlose Updates:** Weitere Projekttypen, Tech-Tree-Erweiterungen, zusätzliche Events.
+- **Community-Wünsche:** Quality-of-Life-Features (Controller, Mod-Support) evaluieren.
+- **Optional Demo:** itch.io Demo für zusätzliche Wishlists (nach Launch bewerten).
 
-**Milestones:**
+---
 
-* **M0 (2 Wochen):** Konzept‑Prototype (Core Loop, 1 Projekt, 1 Minispiel).
-* **M1 (6 Wochen):** Vertical Slice: 3 Projekte, kleiner Tech‑Tree, Ethik‑Event, Ads‑Stub.
-* **M2 (10 Wochen):** Content S0 fertig, Onboarding, Analytics, Crash‑Stabilität ≥ 99,7 %.
-* **M3 (14 Wochen):** Soft‑Launch (2 Länder), A/B‑Tests, Pricing‑Feinschliff.
-* **M4 (18 Wochen):** Global Launch, Season 1 live, Marketing‑Burst.
+## 12) Produktion & Ressourcen
 
-**Budget grob (18 Wochen, EUR):**
-
-* Personal ≈ € 220–280k, Art/Audio € 15k, UA/Marketing Soft‑Launch € 30k, Tools/Backend € 8k, Puffer € 20k → **Summe ≈ € 295–353k**.
+- **Team:** Solo-Dev (Design, Code, Art) + punktuelle Freelancer (Art/SFX) ≤ €150 Budget.
+- **Zeitplan:** 6 Wochen gemäß Milestone-Roadmap, tägliche Fokusblöcke (4–6 h).
+- **Werkzeuge:** Unity Personal, Inkscape, Krita, Audacity, CC0-Asset-Bibliotheken.
+- **Dokumentation:** Wöchentlicher Devlog, Fortschritt im Repo (`docs/diary/` optional).
 
 ---
 
 ## 13) QA, Sicherheit & Compliance
 
-* **QA:** Testpläne für Tutorial, Offline‑Caps, Monetarisierung, Edge‑Geräte (Low‑RAM).
-* **Automatisiert:** Unit‑/Integrationstests (Sim‑Kernel), Device‑Farm Smoke‑Runs.
-* **Datenschutz:** Minimal‑Telemetry, Opt‑in‑Dialoge, Lösch‑Anfragen im Client.
-* **Regeln:** App‑Store‑Guidelines, GDPR, Jugendschutz (12+), keine realen personenbezogenen Daten.
+- **Tests:** Unit-/Property-Tests (Kernel), Play-/Edit-Mode-Tests (Unity), Headless Runner.
+- **Manuelle QA:** Save-Rotation, Offline-Progress, Achievements, Performance (≤ 16 ms FrameTime auf Mittelklasse-PC).
+- **Datenschutz:** Keine personenbezogenen Daten; Impressum/Privacy-Hinweis in Readme/Store.
+- **Lizenzen:** CC0/CC-BY Assets korrekt attribuieren; Third-Party-Libraries dokumentieren.
 
 ---
 
-## 14) Marketing & Launch‑Strategie
+## 14) Marketing & Launch-Plan
 
-* **Pre‑Launch:** Devlog, TikTok/YouTube Shorts (Minispiele), Landing‑Page & Newsletter.
-* **Store‑Assets:** 6 Screenshots, 1 Video (20–30 s), ASO: Keywords „Tycoon, AI, Idle“.
-* **UA:** Soft‑Launch‑Kanäle (Meta, Google App‑Campaigns), Lookalikes ab D7‑Kohorten.
-* **Influencer:** Tech‑YouTuber, Indie‑Dev‑Kanäle; Pressekit mit humorvollen KI‑Bezügen.
-* **Community:** Monats‑Challenges, Discord, Transparenz über Balancing‑Änderungen.
-
----
-
-## 15) Risiko‑Register & Gegenmaßnahmen
-
-| Risiko               | Auswirkung       | Wahrscheinlichkeit | Mitigation                               |
-| -------------------- | ---------------- | -----------------: | ---------------------------------------- |
-| Balancing misslingt  | Churn            |             Mittel | Telemetrie + schnelle Hotfix‑Zyklen      |
-| P2W‑Wahrnehmung      | Negatives Rating |            Niedrig | Klare Fairness‑Leitplanken, No‑Ads‑Kauf  |
-| Gerätefragmentierung | Crashes          |             Mittel | Device‑Farm + Feature‑Fallbacks          |
-| Ethik‑Themen heikel  | PR‑Gegenwind     |            Niedrig | Humorvoll, abstrakt, keine realen Firmen |
-| Content‑Durst        | D7 stagniert     |             Mittel | Seasons + Events Roadmap                 |
+- **Pre-Launch:** Devlog-Serie, Wunschlisten-Kampagne, Newsletter/Discord-Aufbau.
+- **Store-Assets:** 6 Screenshots, 30–45 s Trailer, Capsule-Art in drei Formaten, Feature-Bullets (DE/EN).
+- **Launch-Kommunikation:** Steam-News, Social Posts (Twitter/Bluesky/Mastodon), Indie-Subreddits.
+- **Nach Launch:** Review-Antworten, Patch-Notes, Transparenz über Roadmap.
 
 ---
 
-## 16) Anhang A: Beispiel‑Tech‑Tree (Auszug)
+## 15) Risiko-Register & Mitigation
 
-```
-[Algorithmen]
-  ├─ Transformer‑Basics (FP: 5) → +5% Qualität NLP
-  ├─ RL‑Grundlagen (FP: 5)      → neue Projektklasse „Agenten“
-  └─ Diffusion‑Intro (FP: 6)    → Gen‑Art freigeschaltet
-[Toolchain]
-  ├─ MLOps I (FP: 4)            → -10% Trainingszeit
-  └─ A/B‑Suite (FP: 6)          → Marketingeffizienz +8%
-[Ethik]
-  ├─ Bias‑Monitoring (FP: 4)    → Skandal‑Risiko −15%
-  └─ Red‑Team (FP: 6)           → einmaliger „Skandal‑Blocker“/Season
-```
+| Risiko                         | Auswirkung          | Wahrscheinlichkeit | Mitigation                                                   |
+| ------------------------------ | ------------------- | -----------------: | ------------------------------------------------------------ |
+| Zeitplan rutscht               | Launch verzögert     |              Mittel | Wöchentliche Reviews, Scope kontrollieren                    |
+| Balancing unausgewogen         | Schlechte Reviews    |              Mittel | Headless-Tests, Feedback-Runden, Hotfix-Priorisierung        |
+| Performance-Probleme           | Negative Spielerfahrungen | Niedrig       | Profiling (W5), Zielplattform testen                         |
+| Steamworks-Integration fehlschlägt | Keine Achievements/Overlay | Niedrig | Frühe Implementierung (W1/W4), Fallbacks implementieren      |
+| Art-Assets nicht ausreichend   | Schwache Store-Wirkung | Mittel         | CC0-Packs prüfen, Budget-Puffer für 1–2 Premium-Packs nutzen |
 
 ---
-
-## 17) Anhang B: Beispiel‑Ereignisse
-
-* **„Datensatz‑Leak“:** –10 Reputation; Option „Ehrlicher Report“ (Kosten €), +PR‑Boost später.
-* **„Regulierungs‑Hearing“:** Bei Erfolg Reputation +8, sonst −5 & Lizenzgebühren +2 % für 30 Tage.
-* **„Konferenz‑Best Paper“:** Sofort FP +5; Marketing‑Push Rabatt.
-
----
-
-## 18) Nächste Schritte (konkret)
-
-1. Feasibility‑Prototype (M0): Core Loop + 1 Minispiel + 1 Ethik‑Event.
-2. KPI‑Instrumentierung früh integrieren.
-3. Content‑Pipelines & Remote‑Config vorbereiten (S0/S1).
-4. Soft‑Launch‑Märkte auswählen (z. B. CAN/NZ/SCAND).
-5. Usability‑Tests mit 10–15 Probanden (Think‑Aloud) vor M1.
-
----
-
-> **Erfolgsmesser:** Erreichen der Soft‑Launch‑KPIs, stabile Crash‑Rate, positive Store‑Ratings (≥ 4,3), gesunder Mix aus Ads/IAP. Der Plan unterstützt schnelle Iteration, ethisch sinnvolle Entscheidungen und langfristige Content‑Erweiterbarkeit.

--- a/README.md
+++ b/README.md
@@ -1,16 +1,17 @@
 # KI-Dev-Tycoon Monorepo
 
-Dieses Repository bündelt den Simulations-Kernel (`/sim`) und den zukünftigen Spiel-Client (`/client`) des Projekts **KI-Dev-Tycoon**.
+Dieses Repository bündelt alle Assets für die Solo-MVP-Umsetzung von **KI-Dev-Tycoon** auf Steam (Windows x64, offline). Quelle aller verbindlichen Entscheidungen ist [`Zusatz.md`](./Zusatz.md); sämtliche weiteren Dokumente erweitern oder konkretisieren diesen Anhang.
 
 ## Strukturüberblick
 
 ```
 /README.md              # Diese Übersicht
-/100_schritte_plan.md   # Schrittweiser Ausführungsplan (verbindlich)
-/Gameplan.md            # GDD/PRD mit Vision, Systemdesign & KPIs
-/client/                # Placeholder für Unity-/Godot-Client
-  README.md             # Aktueller Stand & nächste Schritte für den Client
-/sim/                   # Python-Simulationskernel
+/Zusatz.md              # Source of truth (Steam-MVP, Solo-Dev, ≤ €500)
+/100_schritte_plan.md   # Umsetzungsschritte, nach Zusatz.md strukturiert
+/Gameplan.md            # Ergänzende Ableitungen & Referenzen
+/client/                # Unity 6 Client-Grundgerüst
+  README.md             # Setup- und Build-Anweisungen für Unity
+/sim/                   # Python-Simulationskernel (Prototyping & Tests)
   README.md             # Technische Details & Nutzungshinweise
   pyproject.toml        # Poetry-Konfiguration
   src/                  # Python-Quellcode (Paket `ki_dev_tycoon`)
@@ -26,12 +27,13 @@ Dieses Repository bündelt den Simulations-Kernel (`/sim`) und den zukünftigen 
 
 ## Erste Schritte (Client)
 
-*Der Client ist noch nicht initialisiert.* Sobald die Engine gewählt wurde, werden hier Setup-Anweisungen ergänzt.
+Der Unity-Client bildet das UI- und Plattform-Frontend. Folge den Anweisungen in [`client/README.md`](client/README.md), um Unity 6 LTS zu installieren, das Projekt zu öffnen und Builds zu erzeugen. Die Implementierung orientiert sich strikt an den Architekturvorgaben aus `Zusatz.md` (deterministischer Kernel, 0,5 s Tick, Steamworks.NET für Achievements).
 
 ## Weiterführende Dokumente
 
-* `AGENT.md` – Arbeitsanweisungen & Coding-Guidelines für alle Agent:innen.
-* `Gameplan.md` – Vollständiger Produktions- und Game-Design-Plan.
-* `100_schritte_plan.md` – Priorisierte Arbeitsliste mit Abnahmekriterien.
-* `sim/docs/vision_kpis.md` – Vision & KPI-Rahmen für das Projekt.
-* `docs/contributing.md` – Commit- und Branch-Richtlinien (Conventional Commits).
+- `Zusatz.md` – Primäre Produktspezifikation (Steam-MVP, Solo-Dev, ≤ €500).
+- `AGENT.md` – Arbeitsanweisungen & Coding-Guidelines für alle Agent:innen.
+- `Gameplan.md` – Ergänzende Ableitungen (Loops, Referenzen, Visual Style) zum Zusatz.
+- `100_schritte_plan.md` – Schrittplan entlang der in `Zusatz.md` definierten Milestones.
+- `sim/docs/vision_kpis.md` – Legacy-Vision; dient als Inspirationsquelle für KPIs.
+- `docs/contributing.md` – Commit- und Branch-Richtlinien (Conventional Commits).

--- a/Zusatz.md
+++ b/Zusatz.md
@@ -1,0 +1,487 @@
+# Zusatz — KI-Dev-Tycoon (Steam-MVP, Solo-Dev, ≤ €500)
+
+*Stand: 06.10.2025 (Europe/Vienna)*
+
+Dieses Dokument ist die zentrale Referenz für alle Architektur-, Design- und Produktionsentscheidungen des Projekts **KI-Dev-Tycoon**. Ziel ist eine sofort umsetzbare Solo-MVP-Umsetzung auf Steam (Windows, offline) mit einem einmaligen Kaufpreis von €5.99 und einem Gesamtbudget ≤ €500.
+
+---
+
+## 1) Entscheidungen & Projektleitplanken (Summary)
+
+- **Plattform (MVP):** Steam (Windows x64, Desktop)
+- **Team & Budget:** Solo-Entwickler:in, Gesamtbarbudget ≤ €500
+- **Online/Cloud:** Kein Backend, keine Cloud-Komponenten, reine Offline-Simulation
+- **Monetarisierung:** Paid up-front (€5.99), keine Ads, keine IAPs
+- **Region (Launch-Pflicht):** Fokus Österreich (Steam-Release weltweit zulässig)
+- **Engine:** Unity 6 LTS (6000.x)
+- **Architektur:** Strikte Trennung Sim-Kernel (deterministisch) ↔ Client/UI
+- **Tick-Rate:** Fix 0,5 s (Accumulator-Loop)
+- **Achievements:** 8–12 Steam-Achievements (kein Cloud-Save, keine Leaderboards)
+- **Lokalisierung & Accessibility:** EN/DE, skalierbare Schrift, farbenblind-sichere Paletten, reduzierte Animationen optional
+- **Art-Direction:** „Tycoon bunt“, isometrisch/2.5D, kontrastreiche verspielte UI
+- **Nicht-Ziele (MVP):** Keine Ads/IAPs/Push/Telemetry-Cloud/PvP/UGC/Always-Online
+
+---
+
+## 2) Background
+
+**Produktidee & Zielsetzung.** Desktop-Tycoon, der den Aufbau eines KI-Unternehmens simuliert. Fokus: glaubwürdige KI-Anspielungen, Sessions 5–20 Minuten, langfristige Meta-Progression, faire Monetarisierung.
+
+**Plattform & Audience.** Windows (Steam, 16:9, Maus/Keyboard), Zielgruppe 16–45, tech-affin.
+
+**Erfolgsmaße (Post-Launch-Gate).** Wishlist→Kauf-Conversion ≥ 10 % am Launch-Tag, Refund-Rate ≤ 8 %, ≥ 75 % positive Reviews (n≥20), Crash-Rate ≤ 0,3 %.
+
+**Architektur-Leitplanken.** Simulations-Kernel deterministisch (Seed/Time-Injection), Tests ≥ 90 % Coverage, stabile API/Versionierung, CI/CD mit Lint/Typing/Tests. Keine Unity-APIs im Kernel.
+
+**Prozess.** Source of Truth: dieses Dokument. Balancing-Assets nur via Review. Seeds/Snapshots reproduzierbar halten.
+
+---
+
+## 3) Requirements (MoSCoW)
+
+**Must**
+
+- Budget/Team: Solo-Dev, ≤ €500 (inkl. Gebühren/Assets/Store)
+- Plattform: Windows (Steam), 16:9, Ziel 60 FPS; IL2CPP im Release
+- Offline-Only: deterministische Tick-Simulation, lokale Save-Slots + Migration; kein Backend
+- Kern-Loops: Hiring, Forschung (Modelle/Datasets), Training (Kosten/Qualität), Produkt-Launches, Umsatz/Skalierung, Events
+- Monetarisierung: €5.99, ohne Ads/IAPs
+- Distribution: Veröffentlichung mindestens in Österreich
+- Compliance: GDPR-freundlich; minimale Berechtigungen; keine externen Tracker
+- Lokalisierung & Accessibility: EN/DE, skalierbare Schrift, farbenblind-freundliche Paletten
+- Build/CI: Unity 6 LTS, deterministischer Kernel (Tests ≥ 90 %), Lint/Static-Analysis, Nightly Local Builds
+
+**Should**
+
+- Store-Assets: 30–45 s Trailer (In-Engine Captures), 6 Screenshots, Key-Art
+- Steam-Deck-Check: Basiskompatibilität prüfen
+- Optionale Demo: itch.io-Build für Wishlist/Feedback
+
+**Could**
+
+- Cosmetics/Skins, Challenges, erweiterte Achievements
+- Season-Mini-Events (rein kosmetisch)
+
+**Won't (MVP)**
+
+- Ads, IAPs, Remote-Config, Push-Notifications, Telemetrie-Cloud, Always-Online, PvP, UGC
+
+---
+
+## 4) Method (Technische Methode)
+
+### 4.1 Architektur (Steam · Offline · Solo-Dev)
+
+**Engine & Versioning.** Unity 6.0 LTS (6000.x); Export Windows x64; IL2CPP Release, Mono im Editor.
+
+**Steam-Integration.** Steamworks.NET (MIT) für Achievements/Overlay; ohne Steam Cloud; Integration via Unity Package Manager (Git).
+
+**Schichten.**
+
+- `Core.Sim` — deterministischer Sim-Kernel (reines C#, keine Unity-APIs)
+- `Core.Data` — statische Balancing-Daten (ScriptableObjects) + Loader
+- `Game.UI` — UGUI (Canvas/TMP), Presenter/MVP-Pattern
+- `Game.App` — Bootstrap, Tick-Loop, DI-Wire-up, Save/Load
+- `Platform.Steam` — dünner Adapter (Achievements/Rich Presence)
+
+**Determinismus.** Fixe Tick-Rate 0,5 s; `ITimeProvider`/`IRng` injizieren; kein `DateTime.Now` oder `System.Random` im Kernel.
+
+**Persistenz.** JSON + GZip, 1–3 Rotations-Slots, Migrations-Layer `ISaveMigrator` (`vN → vN+1`).
+
+```
+@startuml
+package "Game Client (Unity)" {
+  [Bootstrap] --> [GameLoop]
+  [UI Layer] --> [Presenters]
+}
+package "Core" {
+  [Sim Kernel] --> [RNG]
+  [Sim Kernel] --> [Time Provider]
+  [Sim Kernel] --> [Data Catalog]
+}
+package "Platform" {
+  [Steam Adapter]
+}
+[Bootstrap] --> [Steam Adapter]
+[GameLoop] --> [Sim Kernel]
+[GameLoop] --> [Save System]
+[Presenters] --> [Sim Kernel]
+[Save System] --> [File (JSON.GZ)]
+@enduml
+```
+
+### 4.2 Tick-Loop & Offline-Berechnung
+
+- Fixed-Tick-Accumulator: `acc += delta; while (acc >= Tick) { Sim.Tick(); acc -= Tick; }`
+- Offline-Progress: `dt = clamp(now-lastSave, 0, capHours*3600)`; `n = floor(dt / Tick)`; für große `dt` analytische Formeln (z. B. S-Kurven) statt per-Tick-Iteration
+- Seed & RNG: PCG32 mit `worldSeed`, `companyId`, `dayIndex` als Stream-Keys (replayable)
+
+```
+@startuml
+actor Player
+Player -> App: Start
+App -> SaveSystem: Load(ActiveSlot)
+SaveSystem --> App: SaveState(lastTime, seed, ...)
+App -> Sim: ApplyOfflineProgress(dt)
+App -> UI: ShowMainMenu
+== Runtime ==
+loop Every Frame
+  App -> GameLoop: Update(delta)
+  GameLoop -> Sim: Tick() (0.5s)
+  Sim --> UI: DomainEvents (pub/sub)
+end
+== Quit ==
+UI -> SaveSystem: Save()
+@enduml
+```
+
+### 4.3 Datenmodelle & Schemas (MVP)
+
+**IDs.** Referenzen per `string id` (kebab-case); keine direkten Objekt-Referenzen in Saves.
+
+**ScriptableObjects (statisch).**
+
+- `RoleDef { id, name, baseSalary, skills{ml,data,eng,prod}, hireWeight }`
+- `ResearchNodeDef { id, name, tier, cost, timeHrs, prereqIds[], grants{modelQuality+, infraCap+, featureFlags[]} }`
+- `ProductDef { id, name, segmentId, baseK, baseChurn, priceRange, costPerUser }`
+- `MarketSegmentDef { id, name, TAM, priceElasticity, techAffinity }`
+- `EventDef { id, name, weight, triggerRules, effects{multiplier,target,duration} }`
+
+**Save (JSON v1 Beispiel).**
+
+```json
+{
+  "version": 1,
+  "created_at": "2025-10-06T08:00:00Z",
+  "last_time": "2025-10-06T10:00:00Z",
+  "seed": 9201531,
+  "company": {
+    "name": "My AI Co",
+    "reputation": 0.0,
+    "cash": 20000,
+    "burn_rate": 0,
+    "employees": ["emp-001", "emp-002"],
+    "research_queue": ["res-basic-nlp"],
+    "active_products": ["prod-chatbot-a"]
+  },
+  "employees": {
+    "emp-001": {
+      "role": "ml-engineer",
+      "level": 1,
+      "skills": {"ml": 3, "data": 2, "eng": 2, "prod": 1},
+      "salary": 2200
+    },
+    "emp-002": {
+      "role": "data-scientist",
+      "level": 1,
+      "skills": {"ml": 2, "data": 3, "eng": 1, "prod": 1},
+      "salary": 2100
+    }
+  },
+  "research": {
+    "unlocked": ["res-basic-nlp"],
+    "in_progress": []
+  },
+  "products": {
+    "prod-chatbot-a": {
+      "def": "chatbot",
+      "launch_day": 10,
+      "users": 0,
+      "price": 6.99,
+      "quality": 0.42
+    }
+  },
+  "economy": {"day": 12, "inflation": 0.02},
+  "rng_stream": {"hiring": 12345, "events": 777, "market": 444}
+}
+```
+
+### 4.4 Kern-Formeln (einfach, erweiterbar)
+
+- **Hiring (pro Tag):** `N ~ Poisson(λ)` Kandidat:innen; Qualität `q ~ Normal(μ(role)+β*reputation, σ)`; Gehalt `salary = baseSalary(role) * (1 + q * k_q + marketAdj)`
+- **Forschung/Training (pro Tick):** `dp = (Σ staffSkill * roleWeight) * labMultiplier * (1 - burnout)`; Abschluss bei Σdp ≥ `cost`
+- **Produkt-Qualität:** `quality = tanh(a * modelQuality + b * ln(dataQty + 1) + c * infraCap)`
+- **Adoption (S-Kurve):** `users(t) = K / (1 + e^(−r*(t−t0)))`, `K = TAM * fit(quality, price)`, `r` skaliert mit Reputation/Marketing
+- **Umsatz pro Tick:** `rev = users * price / ticksPerDay * ARPUmult - costPerUser * users / ticksPerDay`
+- **Events:** gewichtete Auswahl; Effekte als Multiplikatoren mit Dauerfenster
+
+### 4.5 Dateistruktur & Pakete
+
+```
+Assets/
+  _Project/
+    Scripts/
+      Core.Sim/
+      Core.Data/
+      Game.UI/
+      Game.App/
+      Platform.Steam/
+    Data/
+      RoleDefs/*.asset
+      Research/*.asset
+      Products/*.asset
+      Markets/*.asset
+      Events/*.asset
+    Resources/
+    Addressables/
+Build/
+```
+
+**Unity-Pakete.** TextMeshPro, Input System, Addressables (lokal), Localization (DE/EN).
+
+### 4.6 Steam-Schnittstellen (MVP-Umfang)
+
+- Init & Overlay: `SteamAPI.Init()` / `SteamAPI.Shutdown()`; Overlay Toggle; `steam_appid.txt` im Projektroot
+- Achievements: 8–12 Ziele (z. B. erstes Produkt, 10k User, erste Forschung Tier 2)
+- Rich Presence: Status-String (z. B. „Day 12 • 1 Product • 5 Staff“)
+
+### 4.7 Vergleichende Referenzen (Design-Ableitungen)
+
+- *Game Dev Tycoon* (Projekt-Phasen → Produkt-Score/Qualität)
+- *Software Inc.* (Personal-Management → Rollen/Skills vereinfacht)
+- *Startup Company* (Feature-Roadmaps → Research-Nodes/Feature-Flags)
+
+### 4.8 Testbarkeit & Determinismus
+
+- Golden-Seeds: fixe Seeds + Save-Snapshots für Regression
+- Property-Tests: Invarianten (Adoption ≤ TAM, Cash nicht negativ ohne Kredit-System)
+- Headless-Runner: CLI-Simulation N-Tage für Balancing-Batches (CSV-Dump lokal)
+
+### 4.9 Visual Style Guide — „Tycoon bunt“ (isometrisch/2.5D)
+
+- **Palette:** Primär Indigo #4F46E5; Akzente Amber #F59E0B, Emerald #10B981, Pink #EC4899; Neutrals #F5F7FB/#FFFFFF; Text #0F172A/#475569; Status Success #16A34A, Warning #F59E0B, Danger #EF4444; Kontrast Body ≥ 4.5:1
+- **Typografie:** Headline Rubik (Semibold), Body Inter (Regular)
+- **Komponenten:** Buttons Radius 14–16 px, Shadow (0,4,12,0.2), Hover +4 %, Press-Scale 0.96; Karten Radius 12 px; Badges/Chips gesättigt; keine 3D-Charts
+- **Icons/Illustration:** isometrisch/2.5D, weicher Schatten (y 6–10, blur 12–18), Licht von rechts oben
+- **Motion:** LeanTween easeOutBack (0.38–0.48 s); Achievement-Toast 250 ms → 1.5 s → 200 ms; Confetti 25–35 Partikel
+- **Audio:** sanfte UI-Foleys; Münz-SFX bei Umsatz-Milestones; Pitch-Varianz ±5 %
+- **A11y:** Farbblind-Check (Deuter/Protan), Fokus-Outline 2 px, Toggle „reduzierte Animationen“
+- **Asset-Pfad:** Vektor-SVG → SDF in Unity; CC0-Packs oder Eigenproduktion (Inkscape/Krita)
+
+---
+
+## 5) Implementation (Schritte)
+
+### 5.1 Projektaufsetzung (Tag 0–1)
+
+- Unity 6 LTS via Hub, neues 2D-Core-Projekt `ai-dev-tycoon`
+- Pakete: TextMeshPro, Input System, Localization, Addressables (lokal)
+- Ordnerstruktur gemäß Abschnitt 4.5, Namespaces `Core.Sim`, `Game.App`, `Game.UI`, `Platform.Steam`
+- Steamworks.NET via UPM-Git; `steam_appid.txt` im Projektroot; SteamManager in Bootstrap-Scene
+- Build-Settings: StandaloneWindows64, IL2CPP (Release), DebugSymbols aus, Stripping Low
+
+### 5.2 Kern-Code-Skeleton (Tag 1–5)
+
+**Zeit & RNG**
+
+```csharp
+public interface ITimeProvider { double UtcNow(); }
+
+public sealed class SystemTimeProvider : ITimeProvider
+{
+    public double UtcNow() => DateTimeOffset.UtcNow.ToUnixTimeSeconds();
+}
+
+public interface IRng
+{
+    uint NextUInt();
+    float Next01();
+}
+
+public sealed class Pcg32 : IRng
+{
+    private ulong _state, _inc;
+
+    public Pcg32(ulong seed, ulong seq)
+    {
+        _state = 0;
+        _inc = (seq << 1) | 1;
+        NextUInt();
+        _state += seed;
+        NextUInt();
+    }
+
+    public uint NextUInt()
+    {
+        ulong old = _state;
+        _state = old * 6364136223846793005UL + _inc;
+        uint xorshift = (uint)(((old >> 18) ^ old) >> 27);
+        int rot = (int)(old >> 59);
+        return (xorshift >> rot) | (xorshift << ((-rot) & 31));
+    }
+
+    public float Next01() => (NextUInt() >> 8) * (1.0f / 16777216f);
+}
+```
+
+**Tick-Loop**
+
+```csharp
+public sealed class GameLoop : MonoBehaviour
+{
+    public float tickSeconds = 0.5f;
+    private float _acc;
+    private Sim _sim;
+    private ITimeProvider _time;
+
+    void Awake()
+    {
+        _time = new SystemTimeProvider();
+        _sim = new Sim(/* deps */);
+    }
+
+    void Update()
+    {
+        _acc += Time.deltaTime;
+        while (_acc >= tickSeconds)
+        {
+            _sim.Tick();
+            _acc -= tickSeconds;
+        }
+    }
+}
+```
+
+**Save/Load (JSON + GZip)**
+
+```csharp
+public static class SaveIO
+{
+    private static string PathFor(string slot)
+        => Path.Combine(Application.persistentDataPath, $"save_{slot}.json.gz");
+
+    public static void Write<T>(string slot, T obj)
+    {
+        var json = JsonSerializer.Serialize(obj);
+        using var fs = File.Create(PathFor(slot));
+        using var gz = new GZipStream(fs, CompressionLevel.SmallestSize);
+        using var sw = new StreamWriter(gz);
+        sw.Write(json);
+    }
+
+    public static T Read<T>(string slot)
+    {
+        using var fs = File.OpenRead(PathFor(slot));
+        using var gz = new GZipStream(fs, CompressionMode.Decompress);
+        using var sr = new StreamReader(gz);
+        var json = sr.ReadToEnd();
+        return JsonSerializer.Deserialize<T>(json)!;
+    }
+}
+```
+
+**Achievements (Steam)**
+
+```csharp
+public static class Ach
+{
+    public static void Unlock(string apiName)
+    {
+        if (!SteamManager.Initialized)
+        {
+            return;
+        }
+
+        SteamUserStats.SetAchievement(apiName);
+        SteamUserStats.StoreStats();
+    }
+}
+```
+
+### 5.3 Daten & Balancing (Tag 3–10)
+
+- ScriptableObjects: 5 Rollen, 12–18 Research-Nodes (Tier 1–3), 3 Produkt-Segmente
+- Start-Ökonomie: Startcash €20k, einfache Mieten/Gehälter, 1 Produkt-Blueprint
+- Events: 6–8 Einsteiger-Events (positiv/negativ) mit Multiplikatoren
+
+### 5.4 UI/UX (Tag 6–14)
+
+- Hauptscreens: HQ-Dashboard (Cash, Burn, Reputation), Team, Forschung, Produkt(e), Markt, Events/Log
+- Navigation: Bottom-Bar (5 Tabs), kontextsensitive Panels, Tooltips
+- Accessibility: Schriftgrößen 90–120 %, farbenblind-freundliche Darstellung
+
+### 5.5 Steam-Setup & Builds (Tag 8–16)
+
+- Steamworks-Partner-Backend: App anlegen, Achievements definieren (8–12)
+- Depot-Struktur: 1× Windows x64 Depot
+- ContentBuilder: `app_build_<appid>.vdf`; Batch für Headless-Build & Upload
+- Store-Seite: Beschreibung (DE/EN), 6 Screenshots, Header Capsule, Preis €5.99, optional „Early Access“
+
+### 5.6 QA & Tests (ab Tag 10, laufend)
+
+- Unit-/Property-Tests für Kernel (Determinismus, Invarianten)
+- Headless-Runner für 30 Ingame-Tage; KPI-Export (CSV) lokal
+- Manuelle QA: Save-Rotation, Achievement-Trigger, Offline-Cap, Performance (FrameTime ≤ 16 ms)
+
+### 5.7 Lokalisierung (Tag 12–15)
+
+- EN zuerst, danach DE; Umschalter im Settings-Menü; Unity Localization Package Keys
+
+### 5.8 Release-Checkliste (Tag 15–18)
+
+- Version `v0.1.0` taggen, Build hochladen, Achievements testen, Pricing/Tax, Altersfreigaben, QA-Pass, Presskit-Readme
+
+### 5.9 Budget (≤ €500; Ziel ≤ €200)
+
+- Fix: Steam Direct Fee ≈ $100 (~€95)
+- Tools: Unity Personal, GIMP/Krita, Inkscape, Audacity (0 €)
+- Assets: bevorzugt freie/CC0-Packs (UI-Icons/SFX/Musik); optional €50–€100 für 1–2 Packs
+- Puffer: Store-Grafiken Budget €50–€150
+
+---
+
+## 6) Milestones
+
+- **W1 — Projekt & Kernel:** Unity-Projekt, Steamworks.NET integriert, Tick-Loop & RNG implementiert, ~30 Unit-Tests grün
+- **W2 — Daten & Ökonomie:** ScriptableObjects, 1 Produkt, Hiring/Forschung/Training, Offline-Cap
+- **W3 — UI-First-Pass:** Greybox aller Screens, Navigation & Tooltips, Save/Load-Rotation
+- **W4 — Steam & Content:** 8–12 Achievements, 6 Screenshots, Capsule-Art V1, Store-Page im Review
+- **W5 — Polish & Beta:** Balancing-Pass, Profiling, DE-Lokalisierung, Bugfix-Sprint
+- **W6 — Release:** v0.1.0 live (AT/global), Preis €5.99, Kommunikations-Post, Hotfix-Plan
+
+---
+
+## 7) Gathering Results (Messung ohne Cloud)
+
+**Launch + 2 Wochen Ziele.** Wishlist→Sale Conversion ≥ 10 %, Refund ≤ 8 %, ≥ 75 % positive Reviews (n≥20), Crash ≤ 0,3 %.
+
+**Messung.** Steam Backoffice (Sales/Refunds/Wishlists/Reviews); optional lokaler CSV-Export im Dev-Modus.
+
+**Gates.**
+
+- Gate A: Umsatz ≥ €1.000 → Steam-Fee kompensiert; Roadmap für Early Access planen
+- Gate B: CR < 5 % oder Reviews < 80 % → Balancing/UX-Pass vor Feature-Erweiterung
+
+---
+
+## 8) Anhang
+
+### 8.1 Achievement-Startliste (Beispiele)
+
+- **First Launch:** Erstes Produkt veröffentlicht
+- **First 1k:** 1.000 Nutzer:innen
+- **First 10k:** 10.000 Nutzer:innen
+- **Tier-2 Unlocked:** Erste Forschung Tier 2 abgeschlossen
+- **Profitable Month:** 30 Tage mit positivem Cashflow
+- **Stable Release:** 7 Tage ohne Crash
+
+### 8.2 Test-Invarianten (Property-Tests)
+
+- Adoption ≤ TAM (pro Segment)
+- Cash wird ohne Kreditsystem nicht negativ
+- Produkt-Qualität ∈ [0, 1]
+- RNG-Streams deterministisch pro Seed/StreamKey
+
+### 8.3 UI-Screens (Wireframe-Plan)
+
+- HQ-Dashboard: Cash, Burn, Reputation, laufende Projekte, Events-Ticker
+- Team: Rollenliste, Bewerbungen (Tagesbatch), Hiring-Dialog
+- Forschung: Tech-Tree (Tier 1–3), Queue, Fortschrittsbalken
+- Produkt: Blueprint → Launch → KPIs (Users/Churn/Revenue)
+- Markt: Segmente, TAM, Preis-/Qualitäts-Fit, Wettbewerbs-Noise (einfach)
+- Events/Log: Zeitlich sortiert, Tooltip-Effekte, Dauer
+
+---
+
+> **Hinweis:** Für Architekturberatung bitte sammuti.com kontaktieren.
+

--- a/client/README.md
+++ b/client/README.md
@@ -1,49 +1,85 @@
-# KI-Dev-Tycoon Client
+# KI-Dev-Tycoon Client (Unity 6 LTS)
 
-Dieses Verzeichnis enthält den Godot-Prototypen für die Foundations-Phase. Der Fokus liegt aktuell darauf, ein lauffähiges Projektgerüst mit Mock-Szenen zu besitzen, das später mit den Daten des Simulations-Kernels verbunden wird.
+Dieses Verzeichnis enthält den Unity-Client für den Steam-MVP von **KI-Dev-Tycoon**. Der Client implementiert UI, Steam-Integration und die Tick-Schleife, während der deterministische Simulationskern (`Core.Sim`) strikt ohne Unity-Abhängigkeiten bleibt. Alle Vorgaben stammen aus [`Zusatz.md`](../Zusatz.md).
 
-## Projektstruktur
+## Projektstruktur (Soll)
 
 ```
 client/
-  godot_project/
-    project.godot          # Godot 4 Konfigurationsdatei
-    scenes/
-      dashboard.tscn       # UI-Mock des Dashboards
-      project_list.tscn    # Wiederverwendbarer Projektslisten-Container
-      resources/
-        title_label.tres   # LabelSettings für den Screen-Titel
-    scripts/
-      project_list_preview.gd  # Renderlogik für Mock-Daten
+  ai-dev-tycoon/                # Unity-Projekt
+    Assets/
+      Scripts/
+        Core.Sim/
+        Core.Data/
+        Game.UI/
+        Game.App/
+        Platform.Steam/
+      Data/
+        RoleDefs/
+        Research/
+        Products/
+        Markets/
+        Events/
+      Resources/
+      Addressables/
+    Packages/
+    ProjectSettings/
   tools/
-    build.py               # Build/Export-Orchestrierung
+    build.ps1                   # Headless Build-Script (Windows)
+    capture_plan.md             # Shot-Liste für Trailer/Screenshots
 ```
+
+> **Hinweis:** Die Ordnerstruktur wird im Laufe von W1–W4 gemäß `100_schritte_plan.md` aufgebaut. Placeholder-Dateien sind erlaubt, solange sie klar als solche markiert sind.
 
 ## Voraussetzungen
 
-* Godot 4.2.x oder neuer muss lokal installiert und über den Befehl `godot4` verfügbar sein.
-* Python 3.11+ für die Build-Hilfsskripte.
+- Unity Hub mit Unity 6000.x LTS (Windows Build Support, IL2CPP, Visual Studio Integration optional).
+- Steamworks.NET (via Git-URL `https://github.com/rlabrecque/Steamworks.NET.git#upm`).
+- Optional: PowerShell ≥ 5.1 bzw. PowerShell Core für Build-Skripte.
+
+## Projekt öffnen
+
+1. Unity Hub starten und auf **Add** → `client/ai-dev-tycoon` zeigen.
+2. Beim ersten Import werden benötigte Pakete (TextMeshPro, Input System, Localization, Addressables) nachinstalliert.
+3. Nach erfolgreichem Import die Szene `Assets/Scenes/Bootstrap.unity` öffnen und im Play Mode prüfen.
 
 ## Build Pipeline
 
-Das Skript `tools/build.py` exportiert die Szenen in ein Distributionsverzeichnis (standardmäßig `build/web`). Es erzeugt eine minimale `index.html`, bindet die Godot-Exportdateien ein (sobald verfügbar) und schreibt Metadaten (z. B. Build-Timestamp).
+Der Build-Prozess folgt den Vorgaben aus `Zusatz.md` (Windows x64, IL2CPP, Offline). Ein minimales PowerShell-Skript kann wie folgt aussehen:
 
-```bash
-cd client
-python -m pip install -r tools/requirements.txt  # optional: linting utilities
-python tools/build.py --export web --output build/web
+```powershell
+param(
+  [string]$ProjectPath = "$(Resolve-Path ../ai-dev-tycoon)",
+  [string]$OutputPath = "$(Resolve-Path ../build)"
+)
+
+$unity = "C:\\Program Files\\Unity\\Hub\\Editor\\6000.0.XXf1\\Editor\\Unity.exe"
+$buildTarget = "StandaloneWindows64"
+$buildMethod = "Game.App.Builds.Cmd.BuildWindows"  # statische Methode im Projekt
+
+& $unity -batchmode -quit -projectPath $ProjectPath -executeMethod $buildMethod -buildTarget $buildTarget -logFile build.log -CustomBuildPath "$OutputPath/KI-Dev-Tycoon.exe"
 ```
 
-Der Export nutzt den Godot-CLI-Aufruf
+Vor dem Build sicherstellen:
 
-```bash
-godot4 --headless --path godot_project --export-release "Web" build/web/KI-Dev-Tycoon.html
-```
+- `steam_appid.txt` liegt im Projektroot.
+- Release-Konfiguration nutzt IL2CPP, Managed Stripping Level „Low“, Debug-Symbole deaktiviert.
+- Addressables/Localization wurden gebuildet (`Addressables Build Player Content`).
 
-Falls der CLI-Befehl nicht gefunden wird oder `--mock-export` gesetzt ist, generiert das Skript einen Platzhalter-Build (HTML + Szenenliste) und erstellt trotzdem das ZIP-Artefakt (`build/KI-Dev-Tycoon-web.zip`). Dadurch bleibt die Pipeline auch ohne Godot-Binary ausführbar.
+## Tests & QA
 
-## Nächste Schritte
+- **Play Mode Tests:** Tick-Schleife (0,5 s), Save/Load Rotation, Offline-Prozess mit simuliertem `dt`.
+- **Edit Mode Tests:** PCG32-RNG, Sim-Invarianten (`Core.Sim`), Daten-Loader.
+- **Headless Runner:** CLI-Tool (C#) führt 30 Ingame-Tage aus und exportiert KPI-CSV (siehe `tools/`-Ordner).
 
-1. Szenen mit realen Daten aus der Simulation befüllen (Schritt 16 ff.).
-2. UI-Komponenten modularisieren und gestylte Themes erstellen.
-3. Automatisierte UI-Tests (Godot GUT) vorbereiten.
+## Steam-Integration Checkliste
+
+1. `SteamAPI.Init()` / `SteamAPI.Shutdown()` werden sicher aufgerufen (inkl. Fallback ohne Steam).
+2. Achievements über `Platform.Steam.Ach.Unlock` an Domain-Events gebunden.
+3. Rich Presence Strings (z. B. „Day 12 • 1 Product • 5 Staff“) aktualisieren sich im Tick.
+4. `steam_appid.txt` wird für Nicht-Steam-Starts entfernt (Build-Skript sorgt dafür).
+
+## Offene Aufgaben
+
+Die detaillierten Aufgaben befinden sich im [`100_schritte_plan.md`](../100_schritte_plan.md) unter den Abschnitten W1–W6. Der Client gilt erst als funktionsfähig, wenn alle W3- und W4-Schritte abgeschlossen und getestet wurden.
+

--- a/sim/README.md
+++ b/sim/README.md
@@ -1,15 +1,14 @@
-# KI Dev Tycoon – Simulation Kernel
+# KI Dev Tycoon – Simulation Kernel (Python Support Stack)
 
-Dieses Repository enthält den deterministischen Python-Kern des Mobile-Spiels **KI Dev Tycoon**. Der Code bildet die Grundlage für weitere Ausbaustufen wie Wirtschaftssimulation, Forschungsbäume, Team-Management sowie API-Anbindung.
+Dieses Verzeichnis enthält den deterministischen Python-Simulationskern, der für Balancing-Experimente, Property-Tests und Tooling rund um den Steam-MVP von **KI Dev Tycoon** eingesetzt wird. Die produktive Implementierung erfolgt laut [`Zusatz.md`](../Zusatz.md) in Unity/C#, doch der Python-Stack bleibt für schnelle Iterationen, Datenexporte und Regressionstests bestehen.
 
 ## Aktueller Stand
 
-- Grundlegende Paketstruktur mit Poetry
-- Deterministische Zufallsquelle (`RandomSource`)
-- Tick-basierter Zeitgeber (`TickClock`)
-- Stark vereinfachte Finanzsimulation inklusive Reputationstracking
-- CLI-Befehl `ki-sim` zur Ausführung einer Beispielsimulation
-- Erste Unit-Tests für RNG und Simulation
+- Paketstruktur mit Poetry (`sim/pyproject.toml`).
+- Deterministische Zufallsquelle (`RandomSource`) und Tick-Zeitgeber (`TickClock`).
+- Vereinfachte Finanzsimulation inklusive Reputationstracking.
+- CLI-Befehl `ki-sim` zur Ausführung deterministischer Beispielsimulationen.
+- Unit- und Property-Tests für RNG, Simulation und Persistenz.
 
 ## Installation
 
@@ -30,7 +29,7 @@ Das Kommando gibt einen JSON-Snapshot mit Kapital- und Reputationswerten auf std
 
 ## API-Adapter (Preview)
 
-Der optionale FastAPI-Adapter stellt unter `/state` einen deterministischen Dummy-State bereit. Er dient aktuell dazu, den Client-Mock (Schritt 15) mit strukturierten Daten zu versorgen.
+Der optionale FastAPI-Adapter stellt unter `/state` deterministische Dummy-States bereit. Damit lassen sich UI-Prototypen oder Analyse-Tools speisen, bis der Unity-Kernel (siehe `Zusatz.md`) voll funktionsfähig ist.
 
 ```bash
 poetry run uvicorn ki_dev_tycoon.api.app:app --reload
@@ -46,7 +45,7 @@ Die Antwortstruktur wird über Pydantic-DTOs in `ki_dev_tycoon/api/dto.py` besch
 poetry run pytest -q
 ```
 
-Weitere Linting- und Typprüfungen können gemäß `pyproject.toml` ausgeführt werden.
+Weitere Linting- und Typprüfungen können gemäß `pyproject.toml` ausgeführt werden. Erkenntnisse aus den Python-Simulationen sind regelmäßig mit den Vorgaben aus `Zusatz.md` und den C#-Implementierungen zu synchronisieren (Seeds, KPIs, Formeln).
 
 ## Code-Qualität & Automatisierung
 


### PR DESCRIPTION
## Summary
- add `Zusatz.md` as the authoritative Steam MVP product specification and sync repository structure references
- rework the 100-step plan, gameplan, and client/sim readmes to follow the solo-dev Steam roadmap defined in Zusatz
- update the root README to point to the new source-of-truth and Unity client workflow

## Testing
- not run (documentation-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68e4303bce1c8327a4397ca348c34eca