### PR TITLE
Document preflight budget confirmation

### DIFF
--- a/100_schritte_plan.md
+++ b/100_schritte_plan.md
@@ -8,7 +8,7 @@ Phasen: **Preflight (1–10)** · **W1 – Projekt & Kernel (11–25)** · **W2 
 
 ## Preflight & Governance (1–10)
 
-1. [ ] Budget-Obergrenze (≤ €500) bestätigen, Ausgaben-Tracker anlegen.
+1. [x] Budget-Obergrenze (≤ €500) bestätigen, Ausgaben-Tracker anlegen. (siehe `docs/preflight/`)
 2. [ ] Steam-Account-Status prüfen (Partner-Programm aktiv, Zahlungsdaten hinterlegt).
 3. [ ] Unity 6 LTS (6000.x) via Hub installieren; Projekteinstellungen für Windows x64 vorbereiten.
 4. [ ] Repository-Setup überprüfen: `Zusatz.md` als Source of Truth referenzieren, Legacy-Dokumente kennzeichnen.

--- a/docs/preflight/budget_tracker.csv
+++ b/docs/preflight/budget_tracker.csv
@@ -1,0 +1,2 @@
+Date,Item,Category,Cost_EUR,Running_Total_EUR,Notes
+2025-10-06,Budget confirmed,Planning,0,0,"Budget cap set to 500 EUR per Zusatz.md"

--- a/docs/preflight/preflight_status.md
+++ b/docs/preflight/preflight_status.md
@@ -1,0 +1,20 @@
+# Preflight Status — KI-Dev-Tycoon
+
+Diese Übersicht dokumentiert den Fortschritt der Preflight-Schritte aus dem `100_schritte_plan.md` und verweist auf zugehörige Artefakte. Alle Entscheidungen sind mit den Leitplanken aus `Zusatz.md` abgeglichen.
+
+## Schritt 1 — Budget-Obergrenze bestätigen & Ausgaben-Tracker anlegen
+- **Status:** Erledigt (2025-10-06)
+- **Budgetlimit:** ≤ €500 Gesamtbudget gemäss `Zusatz.md`
+- **Tracker:** [`budget_tracker.csv`](./budget_tracker.csv) mit laufender Ausgabenübersicht (Datum, Kategorie, Betrag, kumuliert)
+- **Annahmen:** Solo-Dev trägt alle Kosten; initialer Stand 0 €
+- **Nächste Schritte:** Tracker nach jedem Kauf aktualisieren, monatlich mit tatsächlichen Kontoauszügen abgleichen
+
+## Schritt 2 — Steam-Account-Status prüfen (Partner-Programm aktiv, Zahlungsdaten hinterlegt)
+- **Status:** Blockiert (manuelle Prüfung außerhalb des Repos erforderlich)
+- **Letzter Check:** Ausstehend — Zugriff auf Steamworks Partner-Portal wird benötigt
+- **Aktion:** Bei nächstem Login im Steamworks-Dashboard bestätigen, dass Partner-Programm aktiv ist und Zahlungsdaten verifiziert sind; Ergebnis dokumentieren (Screenshot + Kurznotiz)
+- **Risiko:** Verzögerte Auszahlung/Veröffentlichung falls Status unklar; frühzeitig prüfen
+
+## Offene Punkte
+- Schritt 2 muss vor dem Start von Schritt 3 abgeschlossen werden.
+- Ergebnisse nach Durchführung in diesem Dokument ergänzen und den Plan aktualisieren.


### PR DESCRIPTION
## Summary
- mark step 1 of the 100-step plan as complete and reference the new preflight documentation folder
- add a budget tracker CSV and status log covering the confirmed €500 cap and next actions
- record the outstanding Steam partner account verification as a blocked item pending manual confirmation

## Testing
- not run (documentation changes only)


------
https://chatgpt.com/codex/tasks/task_e_68e4bb3487c88327a9535683c4ea2a6a