### PR TITLE
Update preflight governance documentation

### DIFF
--- a/100_schritte_plan.md
+++ b/100_schritte_plan.md
@@ -11,13 +11,13 @@ Phasen: **Preflight (1–10)** · **W1 – Projekt & Kernel (11–25)** · **W2 
 1. [x] Budget-Obergrenze (≤ €500) bestätigen, Ausgaben-Tracker anlegen. (siehe `docs/preflight/`)
 2. [ ] Steam-Account-Status prüfen (Partner-Programm aktiv, Zahlungsdaten hinterlegt).
 3. [ ] Unity 6 LTS (6000.x) via Hub installieren; Projekteinstellungen für Windows x64 vorbereiten.
-4. [ ] Repository-Setup überprüfen: `Zusatz.md` als Source of Truth referenzieren, Legacy-Dokumente kennzeichnen.
-5. [ ] Tooling-Stack festlegen (Rider/VS, Git, Git LFS falls nötig, Art-Tools, Audio-Tools) – ausschließlich kostenfrei.
-6. [ ] Naming- und Namespace-Konventionen definieren (`Core.Sim`, `Game.App`, `Game.UI`, `Platform.Steam`).
+4. [x] Repository-Setup überprüfen: `Zusatz.md` als Source of Truth referenzieren, Legacy-Dokumente kennzeichnen.
+5. [x] Tooling-Stack festlegen (Rider/VS, Git, Git LFS falls nötig, Art-Tools, Audio-Tools) – ausschließlich kostenfrei.
+6. [x] Naming- und Namespace-Konventionen definieren (`Core.Sim`, `Game.App`, `Game.UI`, `Platform.Steam`).
 7. [ ] Issue-/Task-Board für W1–W6 anlegen; Checkpoints aus `Zusatz.md` übertragen.
-8. [ ] Architektur-Risiken erfassen (Determinismus, Save-Migration, Steamworks) und Mitigations notieren.
-9. [ ] Test-Strategie definieren (Unit, Property, Headless-Runner, KPI-CSV) inkl. Seed-Plan.
-10. [ ] Release-Kalender mit Meilensteinen und Deadlines (W1–W6) veröffentlichen.
+8. [x] Architektur-Risiken erfassen (Determinismus, Save-Migration, Steamworks) und Mitigations notieren.
+9. [x] Test-Strategie definieren (Unit, Property, Headless-Runner, KPI-CSV) inkl. Seed-Plan.
+10. [x] Release-Kalender mit Meilensteinen und Deadlines (W1–W6) veröffentlichen.
 
 ---
 

--- a/docs/preflight/naming_conventions.md
+++ b/docs/preflight/naming_conventions.md
@@ -1,0 +1,31 @@
+# Naming- & Namespace-Konventionen — KI-Dev-Tycoon (Preflight Schritt 6)
+
+Die folgenden Konventionen leiten sich aus `Zusatz.md` ab und gelten für das Unity-Projekt (`client/`) sowie ergänzende Tools/Skripte. Sie stellen sicher, dass der deterministische Sim-Kernel klar von der UI/Plattform-Schicht getrennt bleibt.
+
+## C# Namespaces
+- **Core.Sim** — Deterministischer Simulationskernel (keine Unity-Abhängigkeiten). Unterräume:
+  - `Core.Sim.Time`, `Core.Sim.Rng`, `Core.Sim.Economy`, `Core.Sim.Research`, `Core.Sim.Team`, `Core.Sim.Market`, `Core.Sim.Persistence`.
+- **Core.Data** — ScriptableObjects & Datenkataloge (nur Unity Editor-spezifische Klassen zum Laden/Validieren).
+- **Game.App** — Bootstrap, Dependency Injection, Tick-Loop, Save-System.
+- **Game.UI** — UI-Präsentationslogik, Views, Presenter, Input-Handling.
+- **Platform.Steam** — Steamworks.NET Adapter (Achievements, Rich Presence, Initialisierung).
+- **Game.Tests** — EditMode-/PlayMode-Tests (strukturieren nach Feature: `Game.Tests.Core`, `Game.Tests.UI`).
+
+## Dateien & Ordner
+- Unity-Ordner unter `Assets/` spiegeln Namespace-Struktur (`Assets/Scripts/Core/Sim`, `Assets/Scripts/Game/UI`).
+- ScriptableObjects liegen in `Assets/Data/` mit Präfix `SO_` (z. B. `SO_RoleDef.asset`).
+- Editor-spezifische Utilities (`Custom Editors`, `Importers`) in `Assets/Editor/`.
+- Prefabs folgen Schema `Pf_<Kategorie>_<Name>` (z. B. `Pf_UI_Tab_HQ`).
+- Addressables-Gruppen: `ui/*`, `sim/*`, `audio/*`.
+
+## Coding-Standards (Kurzfassung)
+- C#-Dateien im `Core.Sim`-Namespace nutzen `readonly` Felder und Konstruktor-Injektion (kein `MonoBehaviour`).
+- Öffentlich sichtbare Klassen/Methoden mit XML-Dokumentation (für Schritt 24 vorbereiten).
+- Keine Abkürzungen in öffentlichen APIs; PascalCase für Typen, camelCase für Variablen/Felder, UPPER_SNAKE_CASE für Konstanten.
+- Events/Delegates benennen als `SomethingChangedEventArgs`, Handler `OnSomethingChanged`.
+
+## Python / Tools
+- Python-Module im `sim/`-Pfad behalten das existierende Paket `ki_dev_tycoon.*`.
+- Skripte im Repo folgen Snake Case (`export_kpis.py`), Klassen CamelCase.
+
+> **Wartung:** Neue Systeme müssen die Namenskonventionen in Pull Requests dokumentieren. Abweichungen nur mit expliziter ADR.

--- a/docs/preflight/preflight_status.md
+++ b/docs/preflight/preflight_status.md
@@ -11,10 +11,58 @@ Diese Übersicht dokumentiert den Fortschritt der Preflight-Schritte aus dem `10
 
 ## Schritt 2 — Steam-Account-Status prüfen (Partner-Programm aktiv, Zahlungsdaten hinterlegt)
 - **Status:** Blockiert (manuelle Prüfung außerhalb des Repos erforderlich)
-- **Letzter Check:** Ausstehend — Zugriff auf Steamworks Partner-Portal wird benötigt
-- **Aktion:** Bei nächstem Login im Steamworks-Dashboard bestätigen, dass Partner-Programm aktiv ist und Zahlungsdaten verifiziert sind; Ergebnis dokumentieren (Screenshot + Kurznotiz)
-- **Risiko:** Verzögerte Auszahlung/Veröffentlichung falls Status unklar; frühzeitig prüfen
+- **Letzter Check:** 2025-10-06 – Zugriff auf das Steamworks Partner-Portal steht noch aus
+- **Aktion:** Beim nächsten Login im Steamworks-Dashboard bestätigen, dass Partner-Programm aktiv ist und Zahlungsdaten verifiziert sind; Screenshot + Kurznotiz im Repo hinterlegen
+- **Risiko:** Verzögerte Auszahlung/Veröffentlichung falls Status unklar; frühzeitig erledigen
+
+## Schritt 3 — Unity 6 LTS (6000.x) via Hub installieren; Windows-x64-Target vorbereiten
+- **Status:** Blockiert (Unity-Installation außerhalb des Containers nötig)
+- **Letzter Check:** 2025-10-06 – Unity Hub Installation muss lokal erfolgen, kein Zugriff innerhalb des Repos
+- **Aktion:** Unity Hub starten, Unity 6.0 LTS (6000.x) installieren, Windows x64-Build-Support hinzufügen; Installationsnachweis (Version, Pfad) im Repo dokumentieren
+- **Risiko:** Ohne Editor/Build-Support können spätere Schritte (Bootstrap-Szene, Builds) nicht gestartet werden
+
+## Schritt 4 — Repository-Setup prüfen und `Zusatz.md` als Source of Truth referenzieren
+- **Status:** Erledigt (2025-10-06)
+- **Prüfung:** README im Repo-Hauptverzeichnis verweist explizit auf `Zusatz.md` als verbindliche Referenz; `Gameplan.md` und weitere Leitdokumente kennzeichnen sich als Ergänzungen
+- **Aktion:** Keine weiteren Maßnahmen nötig, zukünftige Dokumente müssen denselben Hinweis enthalten
+- **Risiko:** Niedrig – solange neue Dateien die Source-of-Truth-Regel respektieren
+
+## Schritt 5 — Tooling-Stack festlegen (nur kostenfreie Tools)
+- **Status:** Erledigt (2025-10-06)
+- **Dokumentation:** [`tooling_stack.md`](./tooling_stack.md) listet Entwicklungs-, Art-, Audio- und Produktivitäts-Tools, alle lizenzkostenfrei gemäß `Zusatz.md`
+- **Highlights:** VS Code + Visual Studio Community für C#/Unity, Git/GitHub Desktop, Krita/GIMP/Inkscape, Audacity, LibreOffice, draw.io, Unity Hub, Poetry/Nox
+- **Risiko:** Niedrig – regelmäßige Updates prüfen, kostenpflichtige Erweiterungen vermeiden
+
+## Schritt 6 — Naming- und Namespace-Konventionen definieren
+- **Status:** Erledigt (2025-10-06)
+- **Dokumentation:** [`naming_conventions.md`](./naming_conventions.md) beschreibt Struktur für `Core.Sim`, `Game.App`, `Game.UI`, `Platform.Steam` sowie Unity-Asset-Benennung
+- **Highlights:** Einheitliche Namespaces, Ordner-Spiegelung unter `Assets/`, Prefab- und ScriptableObject-Schemata, Coding-Standards
+- **Risiko:** Niedrig – künftige Abweichungen benötigen explizite ADR
+
+## Schritt 7 — Issue-/Task-Board für W1–W6 anlegen
+- **Status:** Blockiert (2025-10-06)
+- **Dokumentation:** [`task_board_plan.md`](./task_board_plan.md) definiert GitHub-Projects-Setup, Spalten & Milestone-Karten
+- **Aktion:** Board im GitHub-Webinterface anlegen und mit Karten befüllen; Link anschließend im Repo ergänzen
+- **Risiko:** Mittel – fehlendes Board erschwert Sprint-Tracking; abhängig von GitHub-Zugriff außerhalb des Repos
+
+## Schritt 8 — Architektur-Risiken erfassen & Mitigations notieren
+- **Status:** Erledigt (2025-10-06)
+- **Dokumentation:** [`risks.md`](./risks.md) fasst Determinismus, Save-Migration, Steamworks, Offline-Progress, Budget & QA-Risiken zusammen
+- **Highlights:** Tabelle mit Beschreibung, Auswirkung, Mitigation; Follow-up-Prozess für Reviews
+- **Risiko:** Mittel – Aktualisierung erforderlich, initiale Abdeckung vorhanden
+
+## Schritt 9 — Test-Strategie definieren (inkl. Seed-Plan)
+- **Status:** Erledigt (2025-10-06)
+- **Dokumentation:** [`test_strategy.md`](./test_strategy.md) beschreibt Testebenen (Unit, Property, Headless, PlayMode) und Seed-Plan
+- **Highlights:** Seed-Zuordnung (`1337`, `7331`, `9001`, `424242`, `20251006`), KPI-CSV-Export, Reporting-Fluss
+- **Risiko:** Mittel – Umsetzung erfordert Einrichtung der Testprojekte in W1
+
+## Schritt 10 — Release-Kalender mit Meilensteinen & Deadlines veröffentlichen
+- **Status:** Erledigt (2025-10-06)
+- **Dokumentation:** [`release_calendar.md`](./release_calendar.md) legt W1–W6 Zeiträume, Deadlines und Launch-Termin fest
+- **Highlights:** Wöchentliche Kerntermine, Reminder-Setup, Abhängigkeit zu Steam-Check (Schritt 2)
+- **Risiko:** Mittel – Verzögerungen müssen via Board & Reports nachverfolgt werden
 
 ## Offene Punkte
-- Schritt 2 muss vor dem Start von Schritt 3 abgeschlossen werden.
-- Ergebnisse nach Durchführung in diesem Dokument ergänzen und den Plan aktualisieren.
+- Schritt 2 bleibt Voraussetzung für die Freigabe von Schritt 3.
+- Nach Abschluss der externen Checks (Steam, Unity) Status hier aktualisieren und den `100_schritte_plan.md` synchronisieren.

--- a/docs/preflight/release_calendar.md
+++ b/docs/preflight/release_calendar.md
@@ -1,0 +1,19 @@
+# Release-Kalender W1–W6 — KI-Dev-Tycoon (Preflight Schritt 10)
+
+Zeitraum: 06.10.2025 – 17.11.2025 (6 Wochen, Start in KW41). Termine können bei Bedarf angepasst werden, müssen aber mit Budget/Scope abgestimmt sein.
+
+| Woche | Zeitraum | Fokus | Kernmeilensteine & Deadlines |
+| --- | --- | --- | --- |
+| W1 | 06.10 – 12.10 | Projekt & Kernel | 06.10: Unity-Projektstart · 08.10: Tick-Loop + RNG Funktionsdemo · 10.10: Save/Load Prototyp · 12.10: SteamManager Placeholder commit |
+| W2 | 13.10 – 19.10 | Daten & Ökonomie | 14.10: ScriptableObject-Defs · 16.10: Forschung/Hiring Systeme Feature-Complete · 18.10: Economy Constants Review · 19.10: Event Picker Test |
+| W3 | 20.10 – 26.10 | UI First Pass | 21.10: Canvas/Layout Setup · 23.10: Tab-Navigation fertig · 24.10: HQ/Team/Forschung Greybox · 26.10: Presenter-Layer + Localization Skeleton |
+| W4 | 27.10 – 02.11 | Steam & Content | 28.10: Steamworks Init final · 29.10: Achievement Hooks · 31.10: Save-Versionierung & Build-Script Draft · 02.11: Store-Text V1 |
+| W5 | 03.11 – 09.11 | Polish & Beta | 04.11: Balancing Pass 1 · 05.11: Profiling Report · 07.11: UI/Audio Polish Check · 09.11: Beta Feedback Review |
+| W6 | 10.11 – 17.11 | Release | 10.11: Final Build Candidate · 12.11: Depot Upload · 14.11: Pricing/Compliance Check · 17.11: Launch Day & Hotfix Plan |
+
+## Reminder & Tracking
+- Kalender als ICS (manuell) in persönlichem Kalender pflegen; Reminder 1–2 Tage vor Deadline.
+- Wöchentliche Review-Notiz (Montag) verlinkt auf relevante Board-Karten.
+- Verzögerungen sofort im Board und in `docs/reports/week_<n>.md` dokumentieren.
+
+> **Hinweis:** Launch-Datum (17.11.2025) setzt voraus, dass Steam-Checks (Schritt 2) bis W2 abgeschlossen sind.

--- a/docs/preflight/risks.md
+++ b/docs/preflight/risks.md
@@ -1,0 +1,12 @@
+# Architektur-Risiken & Mitigations — KI-Dev-Tycoon (Preflight Schritt 8)
+
+| Risiko | Beschreibung | Auswirkung | Mitigation |
+| --- | --- | --- | --- |
+| Determinismusbruch im Sim-Kernel | Direkte Nutzung von `System.Random`, `DateTime.Now` oder Unity-spezifischen Ticks könnte deterministische Abläufe zerstören. | Inkonsistente Savegames, unvorhersehbare Spielerfahrungen, Tests schlagen fehl. | Strikte Nutzung injizierter `IRng`/`ITimeProvider`, Unit-/Property-Tests mit festen Seeds, Code-Reviews auf Random/Time-Aufrufe, CI-Checks (mypy/pytest) im Python-Prototyp. |
+| Save-Migration fehlerhaft | Strukturänderungen ohne Versionierung führen zu inkompatiblen Saves. | Spieler verlieren Fortschritt, negative Reviews. | `ISaveMigrator`-Interface implementieren, Schema-Version in Savegame pflegen, Migrations-Tests (Roundtrip), Dokumentation der Änderungen (`docs/migrations`). |
+| Steamworks-Integration instabil | Falsche Initialisierung/Shutdown, fehlende Callbacks, Achievements werden nicht gespeichert. | Achievements/Overlay funktionieren nicht, QA- und Launch-Risiko. | SteamManager-Wrapper mit Init/Shutdown-GUards, Logging, Integrationstests mit Dummy-AppID, Checklisten für Release (Schritt 69). |
+| Offline-Progress Berechnung fehlerhaft | Große Δt führen zu Overflow oder langer Rechenzeit. | Savegame-Korruption, Softlocks beim Laden. | Analytische Formeln implementieren (Schritt 36), Unit-Tests für Grenzwerte, Cap von 8–12 h, Fallback auf segmentierte Berechnung. |
+| Budgetüberschreitung durch Tools/Assets | Kostenpflichtige Tools oder Assets würden Budgetlimit >€500 verletzen. | Verstoß gegen Projektziel, finanzielle Risiken. | Tooling-Stack ausschließlich kostenfrei (Schritt 5), Ausgaben-Tracker pflegen, jede Ausgabe via `budget_tracker.csv` prüfen. |
+| Fehlende QA-Automatisierung | Ohne Tests/CI schleichen sich Regressionen ein. | Höhere Bugrate, Verzögerungen. | CI-Skripte für Unity/Python aufsetzen (Schritt 23), nightly Builds planen, Tests in PR-Gate erzwingen. |
+
+> **Follow-up:** Risiken in wöchentlichen Reviews aktualisieren; neue Risiken via Issues dokumentieren.

--- a/docs/preflight/task_board_plan.md
+++ b/docs/preflight/task_board_plan.md
@@ -1,0 +1,38 @@
+# Issue- & Task-Board Setup — KI-Dev-Tycoon (Preflight Schritt 7)
+
+Da das tatsächliche GitHub-Projektboard außerhalb des Repos verwaltet wird, beschreibt dieses Dokument die Struktur und Checkpoints gemäß `Zusatz.md`.
+
+## Board-Plattform
+- **Tool:** GitHub Projects (Beta) oder klassische Kanban-Ansicht (kostenfrei).
+- **Projektname:** `KI-Dev-Tycoon Roadmap W1–W6`.
+- **Zugriff:** Privat, nur Solo-Dev; optional Reviewer:innen mit Read-Rechten.
+
+## Spaltenstruktur
+1. **Backlog** – Unpriorisierte Ideen/Stretch-Ziele.
+2. **Todo (Aktueller Sprint)** – Aufgaben der laufenden Woche.
+3. **In Progress** – Aktiv bearbeitete Tasks.
+4. **Review/Blockiert** – Aufgaben mit Pending-Check (z. B. externe Abhängigkeit, QA).
+5. **Done** – Abgeschlossene Tasks mit Tests/Docs.
+
+## Wöchentliche Milestones & Key Tasks
+- **W1 — Projekt & Kernel**
+  - Unity-Projekt erstellen, Tick-Loop + RNG implementieren, Save/Load, Steam-Bootstrap.
+  - Tasks: `Create Unity project`, `Implement TickLoop`, `Design RNG interface`, `Prototype SaveIO`, `SteamManager placeholder`.
+- **W2 — Daten & Ökonomie**
+  - ScriptableObjects, Hiring/Forschung/Training Systeme, Ökonomie-Konstanten, Events.
+  - Tasks: `Define ScriptableObject defs`, `Implement research queue`, `Hiring generator`, `Economy constants`, `Event picker`.
+- **W3 — UI First Pass**
+  - Canvas/Layout, Tab-Navigation, Greybox-Screens, Presenter-Layer, Localization setup.
+- **W4 — Steam & Content**
+  - Achievements, Rich Presence, Save-Versionierung, Store-Assets (Screenshots, Texte), Build-Skripte.
+- **W5 — Polish & Beta**
+  - Balancing-Pass, Profiling, UI-Polish, Audio, Accessibility, Beta feedback.
+- **W6 — Release**
+  - Final Build, Depot Upload, Pricing/Compliance, Launch Runbook, Hotfix Pfad.
+
+## Checkpoints & Reporting
+- Wöchentliche Review-Notiz im Repo (`docs/reports/week_<n>.md`, später erstellen).
+- Offene Blocker (z. B. Steam-Account, Unity-Installation) im Board als Karten (`Blocker: Steam Partner check`).
+- Jede Karte referenziert `Zusatz.md` Abschnitt + relevante Schritt-Nummer.
+
+> **Next Action:** Board im GitHub-Webinterface anlegen, Spalten & Karten laut Liste erstellen, anschließend Link im Repo (z. B. README/Docs) ergänzen.

--- a/docs/preflight/test_strategy.md
+++ b/docs/preflight/test_strategy.md
@@ -1,0 +1,39 @@
+# Test- & QA-Strategie — KI-Dev-Tycoon (Preflight Schritt 9)
+
+Diese Strategie deckt Unit-, Property- und Integrationstests für den deterministischen Sim-Kernel sowie Client-spezifische Prüfungen ab. Grundlage sind die Vorgaben aus `Zusatz.md` (Coverage ≥ 90 %, deterministische Seeds).
+
+## Testebenen
+1. **Unit-Tests (C#)**
+   - Ziel: Einzelne Systeme (`Core.Sim.Time`, `Core.Sim.Rng`, `Core.Sim.Economy`).
+   - Framework: NUnit (Unity Test Framework) im EditMode.
+   - Seeds: `SeedCore = 1337` (Global), Sub-Seeds pro Modul (`rng`, `hiring`, `events`).
+2. **Property-Tests (Python-Prototyp)**
+   - Ziel: Invarianten wie `Quality ∈ [0,1]`, `Cash ≥ 0`, `Adoption ≤ TAM`.
+   - Framework: Hypothesis über `sim/`-Paket; Seeds `PY_SEED = 20251006`.
+3. **Integrationstests / Headless Runner**
+   - Unity Batchmode (`-runTests`) simuliert 30 Ingame-Tage, exportiert KPI-CSV.
+   - CLI: `Unity.exe -batchmode -projectPath <path> -executeMethod Game.Tests.Headless.Run -seed 424242 -days 30 -output kpi.csv`.
+   - Validierung: KPI-Snapshots mit Toleranzen (±2 %).
+4. **PlayMode Smoke Tests**
+   - Automatisierte Szenen-Loads, Tab-Wechsel, Save/Load Roundtrip.
+   - Seeds über `Game.App.Config` injizieren (Default `424242`).
+
+## Seed-Plan
+- **Global Simulation Seed:** `424242` (Production default) – referenziert in Savegames.
+- **Testing Seeds:**
+  - Unit/Core: `1337` (Tick, RNG, Economy), `7331` (Team/Hiring), `9001` (Events).
+  - Property Tests (Python): `20251006` per `PY_SEED` Environment.
+  - Integration/Headless: `424242` (baseline) + `424243` (regression alt).
+- Seeds werden in `docs/testing/seeds.md` (später) versioniert.
+
+## Tooling
+- **Unity:** `UnityEditor.TestTools` für Edit-/PlayMode.
+- **Python:** `poetry run pytest`, `poetry run pytest --maxfail=1 --disable-warnings`, `poetry run mypy`.
+- **CI:** GitHub Actions Matrix (Python 3.11/3.12 + Unity Batch Build).
+
+## Reporting
+- KPI-CSV in `artifacts/tests/<date>/kpi_<seed>.csv`.
+- Coverage-Reports (C# via dotCover oder Unity Coverage Package, Python via `pytest --cov`).
+- Fehlgeschlagene Tests erstellen Issues mit Seed + Repro-Schritten.
+
+> **Next Steps:** Einrichtung der Testprojekte in Woche 1 (Schritte 15–24) und Anlegen eines `docs/testing`-Ordners zur Seed-Versionierung.

--- a/docs/preflight/tooling_stack.md
+++ b/docs/preflight/tooling_stack.md
@@ -1,0 +1,34 @@
+# Tooling-Stack — KI-Dev-Tycoon (Preflight Schritt 5)
+
+Dieser Stack erfüllt die Vorgaben aus `Zusatz.md`: ausschließliche Nutzung kostenfreier Werkzeuge, Fokus auf Windows x64, Solo-Entwicklung. Alle Tools sind lizenzkostenfrei (Community/Open-Source) und decken Programmierung, Versionierung, Art, Audio und Produktivität ab.
+
+## Entwicklungsumgebung
+- **IDE/Editor:** Visual Studio Code (kostenfrei, umfangreiches Ökosystem) mit C#- und Unity-Erweiterungen.
+- **Alternative IDE:** Visual Studio Community 2022 (für C#/Unity, Lizenz frei für Solo-Indies), optional Rider-Ersatz.
+- **Terminal & Shell:** Windows Terminal + PowerShell 7 für Builds/Skripte.
+
+## Versionskontrolle & Zusammenarbeit
+- **Git:** Standard-Versionsverwaltung (bereits im Projekt). GUI-Option: GitHub Desktop (kostenfrei).
+- **Git LFS:** Aktivieren, sobald Binärassets >100 MB anfallen (z. B. Art/Audio-Quellen).
+- **Issue-Tracking:** GitHub Projects/Boards (kostenfrei) für Sprint-Planung.
+
+## Grafik & UI
+- **2D-Art & Texturen:** Krita (Digital Painting) und GIMP (Rasterbearbeitung).
+- **Vektor-Assets & Icons:** Inkscape.
+- **Mockups/Wireframes:** Penpot (Open Source, browserbasiert) oder Figma Free Plan (solange Limit ausreicht).
+
+## Audio
+- **Editing & Mastering:** Audacity.
+- **Sound-Bibliothek:** Sonniss GDC Bundles / freesound.org (CC0) – nur lizenzfreie Quellen verwenden.
+
+## Produktivität & Dokumentation
+- **Notizen/Planung:** Obsidian (kostenfrei für Personal Use) oder Markdown im Repo.
+- **Tabellen/Kalkulation:** LibreOffice Calc (für Budget/Auswertung) zusätzlich zum bestehenden `budget_tracker.csv`.
+- **Mindmaps/Diagramme:** draw.io (diagrams.net) offline/Desktop-Version.
+
+## Builds & Automatisierung
+- **Unity Hub:** Verwaltung der Unity-Installationen (siehe Schritt 3, manuell).
+- **CI-Skripte:** GitHub Actions (bestehende Pipeline) und lokale Batch-/PowerShell-Skripte.
+- **Python-Tooling:** Poetry/Nox (bereits im Repo) für den Sim-Kernel.
+
+> **Hinweis:** Alle Tools müssen regelmäßig auf Updates geprüft werden; kostenpflichtige Erweiterungen sind zu vermeiden, um das Budgetlimit ≤ €500 einzuhalten.


### PR DESCRIPTION
## Summary
- note Steam and Unity preflight checks as blocked and add detailed status for steps 2–10
- publish supporting preflight artifacts covering tooling stack, naming conventions, risk log, test strategy, and release calendar
- mark completed steps in `100_schritte_plan.md` to reflect current progress

## Testing
- not run (documentation-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68e4c3275f708327a084098981fe0e77