### PR TITLE
Introduce Typer CLI and compressed savegames

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,49 @@
+repos:
+  - repo: https://github.com/psf/black
+    rev: 24.8.0
+    hooks:
+      - id: black
+  - repo: https://github.com/pycqa/isort
+    rev: 5.13.2
+    hooks:
+      - id: isort
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.6.8
+    hooks:
+      - id: ruff
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.11.2
+    hooks:
+      - id: mypy
+        additional_dependencies:
+          - pydantic
+  - repo: https://github.com/PyCQA/bandit
+    rev: 1.7.9
+    hooks:
+      - id: bandit
+  - repo: https://github.com/pypa/pip-audit
+    rev: v2.7.3
+    hooks:
+      - id: pip-audit
+  - repo: https://github.com/codespell-project/codespell
+    rev: v2.3.0
+    hooks:
+      - id: codespell
+  - repo: https://github.com/jumanjihouse/pre-commit-hooks
+    rev: 3.0.0
+    hooks:
+      - id: markdownlint
+      - id: shellcheck
+  - repo: local
+    hooks:
+      - id: pytest
+        name: pytest
+        entry: poetry run pytest
+        language: system
+        pass_filenames: false
+      - id: validate-assets
+        name: Validate balancing assets (YAML/JSON schemas)
+        entry: poetry run python scripts/validate_assets.py
+        language: system
+        files: ^assets/.*\.(ya?ml|json)$
+        pass_filenames: false

--- a/scripts/validate_assets.py
+++ b/scripts/validate_assets.py
@@ -1,0 +1,19 @@
+"""Placeholder asset validation script for pre-commit integration."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ASSETS_DIR = Path(__file__).resolve().parents[1] / "assets"
+
+
+def main() -> int:
+    if not ASSETS_DIR.exists():
+        return 0
+    # Real validation will be implemented once assets are introduced.
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI helper
+    sys.exit(main())

--- a/sim/README.md
+++ b/sim/README.md
@@ -4,28 +4,35 @@ Dieses Verzeichnis enthält den deterministischen Python-Simulationskern, der f�
 
 ## Aktueller Stand
 
-- Paketstruktur mit Poetry (`sim/pyproject.toml`).
-- Deterministische Zufallsquelle (`RandomSource`) und Tick-Zeitgeber (`TickClock`).
-- Ökonomische Module (Cashflow, Nachfrage, Reputation) + Forschung/Hiring.
-- CLI-Befehl `ki-sim` zur Ausführung deterministischer Beispielsimulationen.
-- Unit-, Property- und Integrationstests für RNG, Simulation, Persistenz.
+- Typer-basierte CLI (`ki-sim run …`) als Einstiegspunkt für deterministische Simulationen.
+- TickLoop-Komponente mit 0,5 s-Fixschritt und injizierbaren `TimeProvider`-/`RandomSource`-Instanzen.
+- Persistenz über Pydantic-Modelle (`SavegameModel`) mit zstd-Kompression.
+- Unit- und Property-Tests für RNG, TickLoop, Simulation und Persistenz (Hypothesis-basiert).
 
 ## Installation
 
 ```bash
 poetry install --with dev
+pre-commit install
 ```
+
+Die Pre-Commit-Hooks im Repo-Root (`.pre-commit-config.yaml`) führen u. a. `ruff`, `black`, `isort`, `mypy`, `pytest`, `bandit`, `pip-audit`, `codespell`, `markdownlint` und `shellcheck` aus.
 
 ## Simulation ausführen
 
 ```bash
-poetry run ki-sim --ticks 30 --seed 42 \
+poetry run ki-sim run --ticks 30 --seed 42 \
   --daily-active-users 5000 --arp-dau 0.12 --operating-costs 450
 # Optional: detaillierte Tick-Ausgaben aktivieren
-# poetry run ki-sim --ticks 5 --log-level DEBUG
+# poetry run ki-sim run --ticks 5 --log-level DEBUG
 ```
 
-Das Kommando gibt einen JSON-Snapshot mit Kapital- und Reputationswerten auf stdout aus.
+Das Kommando gibt einen JSON-Snapshot mit Kapital- und Reputationswerten auf stdout aus oder schreibt die Datei via `--output` auf die Festplatte. Der zugrunde liegende `run_simulation`-Pfad injiziert Clock/RNG-Factories und nutzt die neue TickLoop.
+
+## Tick-Loop & Persistenz
+
+- `ki_dev_tycoon.core.loop.TickLoop` kapselt den 0,5 s-Zeitakkumulator und erlaubt Tests/Simulationen mit deterministischen Zeitquellen.
+- Savegames werden als zstd-komprimierte JSON-Payload (`SavegameModel`) gespeichert und lassen sich über `encode_savegame`/`decode_savegame` roundtrippen.
 
 ## API-Adapter (optional)
 
@@ -51,7 +58,6 @@ Weitere Linting- und Typprüfungen können gemäß `pyproject.toml` und `noxfile
 
 ## Code-Qualität & Automatisierung
 
-- `pre-commit install` aktiviert lokale Hooks (black, isort, ruff, mypy, pytest).
 - `nox -l` listet verfügbare Sessions.
 - `nox -s lint typecheck tests` führt alle Kernprüfungen aus.
 - `nox -s build` erzeugt PyInstaller-Smoke-Builds (siehe `app/tools`).

--- a/sim/poetry.lock
+++ b/sim/poetry.lock
@@ -113,6 +113,104 @@ jupyter = ["ipython (>=7.8.0)", "tokenize-rt (>=3.2.0)"]
 uvloop = ["uvloop (>=0.15.2)"]
 
 [[package]]
+name = "cffi"
+version = "2.0.0"
+description = "Foreign Function Interface for Python calling C code."
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "platform_python_implementation == \"PyPy\""
+files = [
+    {file = "cffi-2.0.0-cp310-cp310-macosx_10_13_x86_64.whl", hash = "sha256:0cf2d91ecc3fcc0625c2c530fe004f82c110405f101548512cce44322fa8ac44"},
+    {file = "cffi-2.0.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:f73b96c41e3b2adedc34a7356e64c8eb96e03a3782b535e043a986276ce12a49"},
+    {file = "cffi-2.0.0-cp310-cp310-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:53f77cbe57044e88bbd5ed26ac1d0514d2acf0591dd6bb02a3ae37f76811b80c"},
+    {file = "cffi-2.0.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:3e837e369566884707ddaf85fc1744b47575005c0a229de3327f8f9a20f4efeb"},
+    {file = "cffi-2.0.0-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:5eda85d6d1879e692d546a078b44251cdd08dd1cfb98dfb77b670c97cee49ea0"},
+    {file = "cffi-2.0.0-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:9332088d75dc3241c702d852d4671613136d90fa6881da7d770a483fd05248b4"},
+    {file = "cffi-2.0.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:fc7de24befaeae77ba923797c7c87834c73648a05a4bde34b3b7e5588973a453"},
+    {file = "cffi-2.0.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:cf364028c016c03078a23b503f02058f1814320a56ad535686f90565636a9495"},
+    {file = "cffi-2.0.0-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:e11e82b744887154b182fd3e7e8512418446501191994dbf9c9fc1f32cc8efd5"},
+    {file = "cffi-2.0.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:8ea985900c5c95ce9db1745f7933eeef5d314f0565b27625d9a10ec9881e1bfb"},
+    {file = "cffi-2.0.0-cp310-cp310-win32.whl", hash = "sha256:1f72fb8906754ac8a2cc3f9f5aaa298070652a0ffae577e0ea9bd480dc3c931a"},
+    {file = "cffi-2.0.0-cp310-cp310-win_amd64.whl", hash = "sha256:b18a3ed7d5b3bd8d9ef7a8cb226502c6bf8308df1525e1cc676c3680e7176739"},
+    {file = "cffi-2.0.0-cp311-cp311-macosx_10_13_x86_64.whl", hash = "sha256:b4c854ef3adc177950a8dfc81a86f5115d2abd545751a304c5bcf2c2c7283cfe"},
+    {file = "cffi-2.0.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:2de9a304e27f7596cd03d16f1b7c72219bd944e99cc52b84d0145aefb07cbd3c"},
+    {file = "cffi-2.0.0-cp311-cp311-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:baf5215e0ab74c16e2dd324e8ec067ef59e41125d3eade2b863d294fd5035c92"},
+    {file = "cffi-2.0.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:730cacb21e1bdff3ce90babf007d0a0917cc3e6492f336c2f0134101e0944f93"},
+    {file = "cffi-2.0.0-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:6824f87845e3396029f3820c206e459ccc91760e8fa24422f8b0c3d1731cbec5"},
+    {file = "cffi-2.0.0-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:9de40a7b0323d889cf8d23d1ef214f565ab154443c42737dfe52ff82cf857664"},
+    {file = "cffi-2.0.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:8941aaadaf67246224cee8c3803777eed332a19d909b47e29c9842ef1e79ac26"},
+    {file = "cffi-2.0.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:a05d0c237b3349096d3981b727493e22147f934b20f6f125a3eba8f994bec4a9"},
+    {file = "cffi-2.0.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:94698a9c5f91f9d138526b48fe26a199609544591f859c870d477351dc7b2414"},
+    {file = "cffi-2.0.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:5fed36fccc0612a53f1d4d9a816b50a36702c28a2aa880cb8a122b3466638743"},
+    {file = "cffi-2.0.0-cp311-cp311-win32.whl", hash = "sha256:c649e3a33450ec82378822b3dad03cc228b8f5963c0c12fc3b1e0ab940f768a5"},
+    {file = "cffi-2.0.0-cp311-cp311-win_amd64.whl", hash = "sha256:66f011380d0e49ed280c789fbd08ff0d40968ee7b665575489afa95c98196ab5"},
+    {file = "cffi-2.0.0-cp311-cp311-win_arm64.whl", hash = "sha256:c6638687455baf640e37344fe26d37c404db8b80d037c3d29f58fe8d1c3b194d"},
+    {file = "cffi-2.0.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:6d02d6655b0e54f54c4ef0b94eb6be0607b70853c45ce98bd278dc7de718be5d"},
+    {file = "cffi-2.0.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:8eca2a813c1cb7ad4fb74d368c2ffbbb4789d377ee5bb8df98373c2cc0dee76c"},
+    {file = "cffi-2.0.0-cp312-cp312-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:21d1152871b019407d8ac3985f6775c079416c282e431a4da6afe7aefd2bccbe"},
+    {file = "cffi-2.0.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:b21e08af67b8a103c71a250401c78d5e0893beff75e28c53c98f4de42f774062"},
+    {file = "cffi-2.0.0-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:1e3a615586f05fc4065a8b22b8152f0c1b00cdbc60596d187c2a74f9e3036e4e"},
+    {file = "cffi-2.0.0-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:81afed14892743bbe14dacb9e36d9e0e504cd204e0b165062c488942b9718037"},
+    {file = "cffi-2.0.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:3e17ed538242334bf70832644a32a7aae3d83b57567f9fd60a26257e992b79ba"},
+    {file = "cffi-2.0.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3925dd22fa2b7699ed2617149842d2e6adde22b262fcbfada50e3d195e4b3a94"},
+    {file = "cffi-2.0.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:2c8f814d84194c9ea681642fd164267891702542f028a15fc97d4674b6206187"},
+    {file = "cffi-2.0.0-cp312-cp312-win32.whl", hash = "sha256:da902562c3e9c550df360bfa53c035b2f241fed6d9aef119048073680ace4a18"},
+    {file = "cffi-2.0.0-cp312-cp312-win_amd64.whl", hash = "sha256:da68248800ad6320861f129cd9c1bf96ca849a2771a59e0344e88681905916f5"},
+    {file = "cffi-2.0.0-cp312-cp312-win_arm64.whl", hash = "sha256:4671d9dd5ec934cb9a73e7ee9676f9362aba54f7f34910956b84d727b0d73fb6"},
+    {file = "cffi-2.0.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:00bdf7acc5f795150faa6957054fbbca2439db2f775ce831222b66f192f03beb"},
+    {file = "cffi-2.0.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:45d5e886156860dc35862657e1494b9bae8dfa63bf56796f2fb56e1679fc0bca"},
+    {file = "cffi-2.0.0-cp313-cp313-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:07b271772c100085dd28b74fa0cd81c8fb1a3ba18b21e03d7c27f3436a10606b"},
+    {file = "cffi-2.0.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d48a880098c96020b02d5a1f7d9251308510ce8858940e6fa99ece33f610838b"},
+    {file = "cffi-2.0.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:f93fd8e5c8c0a4aa1f424d6173f14a892044054871c771f8566e4008eaa359d2"},
+    {file = "cffi-2.0.0-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:dd4f05f54a52fb558f1ba9f528228066954fee3ebe629fc1660d874d040ae5a3"},
+    {file = "cffi-2.0.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c8d3b5532fc71b7a77c09192b4a5a200ea992702734a2e9279a37f2478236f26"},
+    {file = "cffi-2.0.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:d9b29c1f0ae438d5ee9acb31cadee00a58c46cc9c0b2f9038c6b0b3470877a8c"},
+    {file = "cffi-2.0.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6d50360be4546678fc1b79ffe7a66265e28667840010348dd69a314145807a1b"},
+    {file = "cffi-2.0.0-cp313-cp313-win32.whl", hash = "sha256:74a03b9698e198d47562765773b4a8309919089150a0bb17d829ad7b44b60d27"},
+    {file = "cffi-2.0.0-cp313-cp313-win_amd64.whl", hash = "sha256:19f705ada2530c1167abacb171925dd886168931e0a7b78f5bffcae5c6b5be75"},
+    {file = "cffi-2.0.0-cp313-cp313-win_arm64.whl", hash = "sha256:256f80b80ca3853f90c21b23ee78cd008713787b1b1e93eae9f3d6a7134abd91"},
+    {file = "cffi-2.0.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:fc33c5141b55ed366cfaad382df24fe7dcbc686de5be719b207bb248e3053dc5"},
+    {file = "cffi-2.0.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c654de545946e0db659b3400168c9ad31b5d29593291482c43e3564effbcee13"},
+    {file = "cffi-2.0.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:24b6f81f1983e6df8db3adc38562c83f7d4a0c36162885ec7f7b77c7dcbec97b"},
+    {file = "cffi-2.0.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:12873ca6cb9b0f0d3a0da705d6086fe911591737a59f28b7936bdfed27c0d47c"},
+    {file = "cffi-2.0.0-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:d9b97165e8aed9272a6bb17c01e3cc5871a594a446ebedc996e2397a1c1ea8ef"},
+    {file = "cffi-2.0.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:afb8db5439b81cf9c9d0c80404b60c3cc9c3add93e114dcae767f1477cb53775"},
+    {file = "cffi-2.0.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:737fe7d37e1a1bffe70bd5754ea763a62a066dc5913ca57e957824b72a85e205"},
+    {file = "cffi-2.0.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:38100abb9d1b1435bc4cc340bb4489635dc2f0da7456590877030c9b3d40b0c1"},
+    {file = "cffi-2.0.0-cp314-cp314-win32.whl", hash = "sha256:087067fa8953339c723661eda6b54bc98c5625757ea62e95eb4898ad5e776e9f"},
+    {file = "cffi-2.0.0-cp314-cp314-win_amd64.whl", hash = "sha256:203a48d1fb583fc7d78a4c6655692963b860a417c0528492a6bc21f1aaefab25"},
+    {file = "cffi-2.0.0-cp314-cp314-win_arm64.whl", hash = "sha256:dbd5c7a25a7cb98f5ca55d258b103a2054f859a46ae11aaf23134f9cc0d356ad"},
+    {file = "cffi-2.0.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:9a67fc9e8eb39039280526379fb3a70023d77caec1852002b4da7e8b270c4dd9"},
+    {file = "cffi-2.0.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7a66c7204d8869299919db4d5069a82f1561581af12b11b3c9f48c584eb8743d"},
+    {file = "cffi-2.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:7cc09976e8b56f8cebd752f7113ad07752461f48a58cbba644139015ac24954c"},
+    {file = "cffi-2.0.0-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:92b68146a71df78564e4ef48af17551a5ddd142e5190cdf2c5624d0c3ff5b2e8"},
+    {file = "cffi-2.0.0-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:b1e74d11748e7e98e2f426ab176d4ed720a64412b6a15054378afdb71e0f37dc"},
+    {file = "cffi-2.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:28a3a209b96630bca57cce802da70c266eb08c6e97e5afd61a75611ee6c64592"},
+    {file = "cffi-2.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:7553fb2090d71822f02c629afe6042c299edf91ba1bf94951165613553984512"},
+    {file = "cffi-2.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:6c6c373cfc5c83a975506110d17457138c8c63016b563cc9ed6e056a82f13ce4"},
+    {file = "cffi-2.0.0-cp314-cp314t-win32.whl", hash = "sha256:1fc9ea04857caf665289b7a75923f2c6ed559b8298a1b8c49e59f7dd95c8481e"},
+    {file = "cffi-2.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:d68b6cef7827e8641e8ef16f4494edda8b36104d79773a334beaa1e3521430f6"},
+    {file = "cffi-2.0.0-cp314-cp314t-win_arm64.whl", hash = "sha256:0a1527a803f0a659de1af2e1fd700213caba79377e27e4693648c2923da066f9"},
+    {file = "cffi-2.0.0-cp39-cp39-macosx_10_13_x86_64.whl", hash = "sha256:fe562eb1a64e67dd297ccc4f5addea2501664954f2692b69a76449ec7913ecbf"},
+    {file = "cffi-2.0.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:de8dad4425a6ca6e4e5e297b27b5c824ecc7581910bf9aee86cb6835e6812aa7"},
+    {file = "cffi-2.0.0-cp39-cp39-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:4647afc2f90d1ddd33441e5b0e85b16b12ddec4fca55f0d9671fef036ecca27c"},
+    {file = "cffi-2.0.0-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:3f4d46d8b35698056ec29bca21546e1551a205058ae1a181d871e278b0b28165"},
+    {file = "cffi-2.0.0-cp39-cp39-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:e6e73b9e02893c764e7e8d5bb5ce277f1a009cd5243f8228f75f842bf937c534"},
+    {file = "cffi-2.0.0-cp39-cp39-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:cb527a79772e5ef98fb1d700678fe031e353e765d1ca2d409c92263c6d43e09f"},
+    {file = "cffi-2.0.0-cp39-cp39-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:61d028e90346df14fedc3d1e5441df818d095f3b87d286825dfcbd6459b7ef63"},
+    {file = "cffi-2.0.0-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:0f6084a0ea23d05d20c3edcda20c3d006f9b6f3fefeac38f59262e10cef47ee2"},
+    {file = "cffi-2.0.0-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:1cd13c99ce269b3ed80b417dcd591415d3372bcac067009b6e0f59c7d4015e65"},
+    {file = "cffi-2.0.0-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:89472c9762729b5ae1ad974b777416bfda4ac5642423fa93bd57a09204712322"},
+    {file = "cffi-2.0.0-cp39-cp39-win32.whl", hash = "sha256:2081580ebb843f759b9f617314a24ed5738c51d2aee65d31e02f6f7a2b97707a"},
+    {file = "cffi-2.0.0-cp39-cp39-win_amd64.whl", hash = "sha256:b882b3df248017dba09d6b16defe9b5c407fe32fc7c65a9c69798e6175601be9"},
+    {file = "cffi-2.0.0.tar.gz", hash = "sha256:44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529"},
+]
+
+[package.dependencies]
+pycparser = {version = "*", markers = "implementation_name != \"PyPy\""}
+
+[[package]]
 name = "cfgv"
 version = "3.4.0"
 description = "Validate configuration and produce human readable error messages."
@@ -130,7 +228,7 @@ version = "8.3.0"
 description = "Composable command line interface toolkit"
 optional = false
 python-versions = ">=3.10"
-groups = ["dev"]
+groups = ["main", "dev"]
 files = [
     {file = "click-8.3.0-py3-none-any.whl", hash = "sha256:9b9f285302c6e3064f4330c05f05b81945b2a39544279343e6e7c5f27a9baddc"},
     {file = "click-8.3.0.tar.gz", hash = "sha256:e7b8232224eba16f4ebe410c25ced9f7875cb5f3263ffc93cc3e8da705e229c4"},
@@ -145,12 +243,12 @@ version = "0.4.6"
 description = "Cross-platform colored terminal text."
 optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*,>=2.7"
-groups = ["dev"]
-markers = "sys_platform == \"win32\" or platform_system == \"Windows\""
+groups = ["main", "dev"]
 files = [
     {file = "colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"},
     {file = "colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44"},
 ]
+markers = {main = "platform_system == \"Windows\"", dev = "platform_system == \"Windows\" or sys_platform == \"win32\""}
 
 [[package]]
 name = "colorlog"
@@ -305,6 +403,42 @@ files = [
 
 [package.extras]
 colors = ["colorama (>=0.4.6)"]
+
+[[package]]
+name = "markdown-it-py"
+version = "4.0.0"
+description = "Python port of markdown-it. Markdown parsing, done right!"
+optional = false
+python-versions = ">=3.10"
+groups = ["main"]
+files = [
+    {file = "markdown_it_py-4.0.0-py3-none-any.whl", hash = "sha256:87327c59b172c5011896038353a81343b6754500a08cd7a4973bb48c6d578147"},
+    {file = "markdown_it_py-4.0.0.tar.gz", hash = "sha256:cb0a2b4aa34f932c007117b194e945bd74e0ec24133ceb5bac59009cda1cb9f3"},
+]
+
+[package.dependencies]
+mdurl = ">=0.1,<1.0"
+
+[package.extras]
+benchmarking = ["psutil", "pytest", "pytest-benchmark"]
+compare = ["commonmark (>=0.9,<1.0)", "markdown (>=3.4,<4.0)", "markdown-it-pyrs", "mistletoe (>=1.0,<2.0)", "mistune (>=3.0,<4.0)", "panflute (>=2.3,<3.0)"]
+linkify = ["linkify-it-py (>=1,<3)"]
+plugins = ["mdit-py-plugins (>=0.5.0)"]
+profiling = ["gprof2dot"]
+rtd = ["ipykernel", "jupyter_sphinx", "mdit-py-plugins (>=0.5.0)", "myst-parser", "pyyaml", "sphinx", "sphinx-book-theme (>=1.0,<2.0)", "sphinx-copybutton", "sphinx-design"]
+testing = ["coverage", "pytest", "pytest-cov", "pytest-regressions", "requests"]
+
+[[package]]
+name = "mdurl"
+version = "0.1.2"
+description = "Markdown URL utilities"
+optional = false
+python-versions = ">=3.7"
+groups = ["main"]
+files = [
+    {file = "mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8"},
+    {file = "mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba"},
+]
 
 [[package]]
 name = "mypy"
@@ -501,6 +635,19 @@ files = [
 ]
 
 [[package]]
+name = "pycparser"
+version = "2.23"
+description = "C parser in Python"
+optional = false
+python-versions = ">=3.8"
+groups = ["main"]
+markers = "platform_python_implementation == \"PyPy\" and implementation_name != \"PyPy\""
+files = [
+    {file = "pycparser-2.23-py3-none-any.whl", hash = "sha256:e5c6e8d3fbad53479cab09ac03729e0a9faf2bee3db8208a550daf5af81a5934"},
+    {file = "pycparser-2.23.tar.gz", hash = "sha256:78816d4f24add8f10a06d6f05b4d424ad9e96cfebf68a4ddc99c65c0720d00c2"},
+]
+
+[[package]]
 name = "pydantic"
 version = "2.11.10"
 description = "Data validation using Python type hints"
@@ -640,7 +787,7 @@ version = "2.19.2"
 description = "Pygments is a syntax highlighting package written in Python."
 optional = false
 python-versions = ">=3.8"
-groups = ["dev"]
+groups = ["main", "dev"]
 files = [
     {file = "pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b"},
     {file = "pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887"},
@@ -776,6 +923,25 @@ files = [
 ]
 
 [[package]]
+name = "rich"
+version = "14.1.0"
+description = "Render rich text, tables, progress bars, syntax highlighting, markdown and more to the terminal"
+optional = false
+python-versions = ">=3.8.0"
+groups = ["main"]
+files = [
+    {file = "rich-14.1.0-py3-none-any.whl", hash = "sha256:536f5f1785986d6dbdea3c75205c473f970777b4a0d6c6dd1b696aa05a3fa04f"},
+    {file = "rich-14.1.0.tar.gz", hash = "sha256:e497a48b844b0320d45007cdebfeaeed8db2a4f4bcf49f15e455cfc4af11eaa8"},
+]
+
+[package.dependencies]
+markdown-it-py = ">=2.2.0"
+pygments = ">=2.13.0,<3.0.0"
+
+[package.extras]
+jupyter = ["ipywidgets (>=7.5.1,<9)"]
+
+[[package]]
 name = "ruff"
 version = "0.6.9"
 description = "An extremely fast Python linter and code formatter, written in Rust."
@@ -801,6 +967,18 @@ files = [
     {file = "ruff-0.6.9-py3-none-win_amd64.whl", hash = "sha256:785d31851c1ae91f45b3d8fe23b8ae4b5170089021fbb42402d811135f0b7117"},
     {file = "ruff-0.6.9-py3-none-win_arm64.whl", hash = "sha256:a9641e31476d601f83cd602608739a0840e348bda93fec9f1ee816f8b6798b93"},
     {file = "ruff-0.6.9.tar.gz", hash = "sha256:b076ef717a8e5bc819514ee1d602bbdca5b4420ae13a9cf61a0c0a4f53a2baa2"},
+]
+
+[[package]]
+name = "shellingham"
+version = "1.5.4"
+description = "Tool to Detect Surrounding Shell"
+optional = false
+python-versions = ">=3.7"
+groups = ["main"]
+files = [
+    {file = "shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686"},
+    {file = "shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de"},
 ]
 
 [[package]]
@@ -844,6 +1022,24 @@ anyio = ">=3.6.2,<5"
 
 [package.extras]
 full = ["httpx (>=0.27.0,<0.29.0)", "itsdangerous", "jinja2", "python-multipart (>=0.0.18)", "pyyaml"]
+
+[[package]]
+name = "typer"
+version = "0.12.5"
+description = "Typer, build great CLIs. Easy to code. Based on Python type hints."
+optional = false
+python-versions = ">=3.7"
+groups = ["main"]
+files = [
+    {file = "typer-0.12.5-py3-none-any.whl", hash = "sha256:62fe4e471711b147e3365034133904df3e235698399bc4de2b36c8579298d52b"},
+    {file = "typer-0.12.5.tar.gz", hash = "sha256:f592f089bedcc8ec1b974125d64851029c3b1af145f04aca64d69410f0c9b722"},
+]
+
+[package.dependencies]
+click = ">=8.0.0"
+rich = ">=10.11.0"
+shellingham = ">=1.3.0"
+typing-extensions = ">=3.7.4.3"
 
 [[package]]
 name = "types-requests"
@@ -926,7 +1122,69 @@ platformdirs = ">=3.9.1,<5"
 docs = ["furo (>=2023.7.26)", "proselint (>=0.13)", "sphinx (>=7.1.2,!=7.3)", "sphinx-argparse (>=0.4)", "sphinxcontrib-towncrier (>=0.2.1a0)", "towncrier (>=23.6)"]
 test = ["covdefaults (>=2.3)", "coverage (>=7.2.7)", "coverage-enable-subprocess (>=1)", "flaky (>=3.7)", "packaging (>=23.1)", "pytest (>=7.4)", "pytest-env (>=0.8.2)", "pytest-freezer (>=0.4.8) ; platform_python_implementation == \"PyPy\" or platform_python_implementation == \"GraalVM\" or platform_python_implementation == \"CPython\" and sys_platform == \"win32\" and python_version >= \"3.13\"", "pytest-mock (>=3.11.1)", "pytest-randomly (>=3.12)", "pytest-timeout (>=2.1)", "setuptools (>=68)", "time-machine (>=2.10) ; platform_python_implementation == \"CPython\""]
 
+[[package]]
+name = "zstandard"
+version = "0.22.0"
+description = "Zstandard bindings for Python"
+optional = false
+python-versions = ">=3.8"
+groups = ["main"]
+files = [
+    {file = "zstandard-0.22.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:275df437ab03f8c033b8a2c181e51716c32d831082d93ce48002a5227ec93019"},
+    {file = "zstandard-0.22.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:2ac9957bc6d2403c4772c890916bf181b2653640da98f32e04b96e4d6fb3252a"},
+    {file = "zstandard-0.22.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:fe3390c538f12437b859d815040763abc728955a52ca6ff9c5d4ac707c4ad98e"},
+    {file = "zstandard-0.22.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1958100b8a1cc3f27fa21071a55cb2ed32e9e5df4c3c6e661c193437f171cba2"},
+    {file = "zstandard-0.22.0-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:93e1856c8313bc688d5df069e106a4bc962eef3d13372020cc6e3ebf5e045202"},
+    {file = "zstandard-0.22.0-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:1a90ba9a4c9c884bb876a14be2b1d216609385efb180393df40e5172e7ecf356"},
+    {file = "zstandard-0.22.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:3db41c5e49ef73641d5111554e1d1d3af106410a6c1fb52cf68912ba7a343a0d"},
+    {file = "zstandard-0.22.0-cp310-cp310-win32.whl", hash = "sha256:d8593f8464fb64d58e8cb0b905b272d40184eac9a18d83cf8c10749c3eafcd7e"},
+    {file = "zstandard-0.22.0-cp310-cp310-win_amd64.whl", hash = "sha256:f1a4b358947a65b94e2501ce3e078bbc929b039ede4679ddb0460829b12f7375"},
+    {file = "zstandard-0.22.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:589402548251056878d2e7c8859286eb91bd841af117dbe4ab000e6450987e08"},
+    {file = "zstandard-0.22.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:a97079b955b00b732c6f280d5023e0eefe359045e8b83b08cf0333af9ec78f26"},
+    {file = "zstandard-0.22.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:445b47bc32de69d990ad0f34da0e20f535914623d1e506e74d6bc5c9dc40bb09"},
+    {file = "zstandard-0.22.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:33591d59f4956c9812f8063eff2e2c0065bc02050837f152574069f5f9f17775"},
+    {file = "zstandard-0.22.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:888196c9c8893a1e8ff5e89b8f894e7f4f0e64a5af4d8f3c410f0319128bb2f8"},
+    {file = "zstandard-0.22.0-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:53866a9d8ab363271c9e80c7c2e9441814961d47f88c9bc3b248142c32141d94"},
+    {file = "zstandard-0.22.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:4ac59d5d6910b220141c1737b79d4a5aa9e57466e7469a012ed42ce2d3995e88"},
+    {file = "zstandard-0.22.0-cp311-cp311-win32.whl", hash = "sha256:2b11ea433db22e720758cba584c9d661077121fcf60ab43351950ded20283440"},
+    {file = "zstandard-0.22.0-cp311-cp311-win_amd64.whl", hash = "sha256:11f0d1aab9516a497137b41e3d3ed4bbf7b2ee2abc79e5c8b010ad286d7464bd"},
+    {file = "zstandard-0.22.0-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:6c25b8eb733d4e741246151d895dd0308137532737f337411160ff69ca24f93a"},
+    {file = "zstandard-0.22.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:f9b2cde1cd1b2a10246dbc143ba49d942d14fb3d2b4bccf4618d475c65464912"},
+    {file = "zstandard-0.22.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a88b7df61a292603e7cd662d92565d915796b094ffb3d206579aaebac6b85d5f"},
+    {file = "zstandard-0.22.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:466e6ad8caefb589ed281c076deb6f0cd330e8bc13c5035854ffb9c2014b118c"},
+    {file = "zstandard-0.22.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a1d67d0d53d2a138f9e29d8acdabe11310c185e36f0a848efa104d4e40b808e4"},
+    {file = "zstandard-0.22.0-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:39b2853efc9403927f9065cc48c9980649462acbdf81cd4f0cb773af2fd734bc"},
+    {file = "zstandard-0.22.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:8a1b2effa96a5f019e72874969394edd393e2fbd6414a8208fea363a22803b45"},
+    {file = "zstandard-0.22.0-cp312-cp312-win32.whl", hash = "sha256:88c5b4b47a8a138338a07fc94e2ba3b1535f69247670abfe422de4e0b344aae2"},
+    {file = "zstandard-0.22.0-cp312-cp312-win_amd64.whl", hash = "sha256:de20a212ef3d00d609d0b22eb7cc798d5a69035e81839f549b538eff4105d01c"},
+    {file = "zstandard-0.22.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:d75f693bb4e92c335e0645e8845e553cd09dc91616412d1d4650da835b5449df"},
+    {file = "zstandard-0.22.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:36a47636c3de227cd765e25a21dc5dace00539b82ddd99ee36abae38178eff9e"},
+    {file = "zstandard-0.22.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:68953dc84b244b053c0d5f137a21ae8287ecf51b20872eccf8eaac0302d3e3b0"},
+    {file = "zstandard-0.22.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2612e9bb4977381184bb2463150336d0f7e014d6bb5d4a370f9a372d21916f69"},
+    {file = "zstandard-0.22.0-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:23d2b3c2b8e7e5a6cb7922f7c27d73a9a615f0a5ab5d0e03dd533c477de23004"},
+    {file = "zstandard-0.22.0-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:1d43501f5f31e22baf822720d82b5547f8a08f5386a883b32584a185675c8fbf"},
+    {file = "zstandard-0.22.0-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:a493d470183ee620a3df1e6e55b3e4de8143c0ba1b16f3ded83208ea8ddfd91d"},
+    {file = "zstandard-0.22.0-cp38-cp38-win32.whl", hash = "sha256:7034d381789f45576ec3f1fa0e15d741828146439228dc3f7c59856c5bcd3292"},
+    {file = "zstandard-0.22.0-cp38-cp38-win_amd64.whl", hash = "sha256:d8fff0f0c1d8bc5d866762ae95bd99d53282337af1be9dc0d88506b340e74b73"},
+    {file = "zstandard-0.22.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:2fdd53b806786bd6112d97c1f1e7841e5e4daa06810ab4b284026a1a0e484c0b"},
+    {file = "zstandard-0.22.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:73a1d6bd01961e9fd447162e137ed949c01bdb830dfca487c4a14e9742dccc93"},
+    {file = "zstandard-0.22.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9501f36fac6b875c124243a379267d879262480bf85b1dbda61f5ad4d01b75a3"},
+    {file = "zstandard-0.22.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:48f260e4c7294ef275744210a4010f116048e0c95857befb7462e033f09442fe"},
+    {file = "zstandard-0.22.0-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:959665072bd60f45c5b6b5d711f15bdefc9849dd5da9fb6c873e35f5d34d8cfb"},
+    {file = "zstandard-0.22.0-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:d22fdef58976457c65e2796e6730a3ea4a254f3ba83777ecfc8592ff8d77d303"},
+    {file = "zstandard-0.22.0-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:a7ccf5825fd71d4542c8ab28d4d482aace885f5ebe4b40faaa290eed8e095a4c"},
+    {file = "zstandard-0.22.0-cp39-cp39-win32.whl", hash = "sha256:f058a77ef0ece4e210bb0450e68408d4223f728b109764676e1a13537d056bb0"},
+    {file = "zstandard-0.22.0-cp39-cp39-win_amd64.whl", hash = "sha256:e9e9d4e2e336c529d4c435baad846a181e39a982f823f7e4495ec0b0ec8538d2"},
+    {file = "zstandard-0.22.0.tar.gz", hash = "sha256:8226a33c542bcb54cd6bd0a366067b610b41713b64c9abec1bc4533d69f51e70"},
+]
+
+[package.dependencies]
+cffi = {version = ">=1.11", markers = "platform_python_implementation == \"PyPy\""}
+
+[package.extras]
+cffi = ["cffi (>=1.11)"]
+
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.11"
-content-hash = "143a84ebf73f1bfe3a24b81e43794ae8ff44ec0377d5006bebcde2977be781e1"
+content-hash = "ec097b13707d5d75bbeb5475fe9c7f31daca84a7bc7b3e68e8717c857d728dac"

--- a/sim/pyproject.toml
+++ b/sim/pyproject.toml
@@ -10,7 +10,9 @@ packages = [{ include = "ki_dev_tycoon", from = "src" }]
 [tool.poetry.dependencies]
 python = "^3.11"
 pydantic = "^2.9.0"
+typer = "^0.12.5"
 pyyaml = "^6.0.2"
+zstandard = "^0.22.0"
 fastapi = "^0.115.0"
 
 [tool.poetry.group.dev.dependencies]

--- a/sim/src/ki_dev_tycoon/cli/__init__.py
+++ b/sim/src/ki_dev_tycoon/cli/__init__.py
@@ -1,0 +1,5 @@
+"""Typer-based command line entrypoints for simulation tooling."""
+
+from .sim import app
+
+__all__ = ["app"]

--- a/sim/src/ki_dev_tycoon/cli/sim.py
+++ b/sim/src/ki_dev_tycoon/cli/sim.py
@@ -1,0 +1,81 @@
+"""Simulation CLI implemented with Typer."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Optional, Sequence
+
+import typer
+
+from ki_dev_tycoon.app import SimulationConfig, run_simulation
+from ki_dev_tycoon.utils.logging import configure_logging, get_logger
+
+app = typer.Typer(help="Run deterministic KI Dev Tycoon simulations.")
+
+
+@app.command()
+def run(
+    *,
+    ticks: int = typer.Option(30, min=1, help="Number of simulated days to process."),
+    seed: int = typer.Option(42, help="Deterministic random seed used for RNG initialisation."),
+    daily_active_users: int = typer.Option(
+        5_000, min=0, help="Active users per day in the simulation."
+    ),
+    arp_dau: float = typer.Option(
+        0.12, help="Average revenue per daily active user in Euro."
+    ),
+    operating_costs: float = typer.Option(
+        450.0, help="Daily operating costs in Euro."
+    ),
+    output: Optional[Path] = typer.Option(
+        None,
+        "--output",
+        "-o",
+        help="Optional path to write the JSON result to.",
+        metavar="PATH",
+    ),
+    log_level: str = typer.Option(
+        "INFO",
+        help="Logging verbosity for the simulation run.",
+        case_sensitive=False,
+    ),
+) -> None:
+    """Run the deterministic simulation for ``ticks`` days."""
+
+    configure_logging(log_level.upper())
+    sim_logger = get_logger("simulation")
+
+    config = SimulationConfig(
+        ticks=ticks,
+        seed=seed,
+        daily_active_users=daily_active_users,
+        arp_dau=arp_dau,
+        operating_costs=operating_costs,
+    )
+
+    result = run_simulation(config, logger=sim_logger)
+    payload = json.dumps(result.model_dump(), indent=2)
+
+    if output is None:
+        typer.echo(payload)
+        return
+
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(payload + "\n", encoding="utf-8")
+    typer.echo(f"Result written to {output}")
+
+
+def run_cli(argv: Optional[Sequence[str]] = None) -> int:
+    """Execute the Typer application with the provided arguments."""
+
+    command = typer.main.get_command(app)
+    try:
+        command.main(
+            args=list(argv) if argv is not None else None,
+            prog_name="ki-sim",
+            standalone_mode=False,
+        )
+    except SystemExit as exc:  # pragma: no cover - click compatibility guard
+        return int(exc.code or 0)
+    return 0

--- a/sim/src/ki_dev_tycoon/core/__init__.py
+++ b/sim/src/ki_dev_tycoon/core/__init__.py
@@ -7,11 +7,13 @@ from .events import (
     SimulationStarted,
     TickProcessed,
 )
+from .loop import TickLoop
 from .rng import RandomSource
 from .time import FrozenTime, TickClock, TimeProvider
 
 __all__ = [
     "EventBus",
+    "TickLoop",
     "RandomSource",
     "TickClock",
     "TimeProvider",

--- a/sim/src/ki_dev_tycoon/core/loop.py
+++ b/sim/src/ki_dev_tycoon/core/loop.py
@@ -1,0 +1,73 @@
+"""Deterministic tick loop with accumulator semantics."""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass, field
+from typing import Callable
+
+from ki_dev_tycoon.core.rng import RandomSource
+from ki_dev_tycoon.core.time import TimeProvider
+
+TickHandler = Callable[[int, RandomSource], None]
+TimeSource = Callable[[], float]
+SleepFunction = Callable[[float], None]
+
+
+@dataclass(slots=True)
+class TickLoop:
+    """Fixed-step accumulator loop for deterministic tick processing."""
+
+    clock: TimeProvider
+    rng: RandomSource
+    tick_duration: float = 0.5
+    time_source: TimeSource | None = None
+    sleep: SleepFunction | None = None
+    _accumulator: float = field(default=0.0, init=False)
+    _last_time: float = field(default=0.0, init=False)
+
+    def __post_init__(self) -> None:
+        if self.tick_duration <= 0:
+            msg = "TickLoop requires a positive tick_duration"
+            raise ValueError(msg)
+        if self.time_source is None:
+            self.time_source = time.perf_counter
+        if self.sleep is None:
+            self.sleep = lambda _: None
+        self._last_time = self.time_source()
+
+    def advance_by(self, delta_seconds: float, handler: TickHandler) -> int:
+        """Advance the loop by ``delta_seconds`` and process pending ticks."""
+
+        if delta_seconds < 0:
+            msg = "TickLoop cannot be advanced by a negative duration"
+            raise ValueError(msg)
+        processed = 0
+        self._accumulator += delta_seconds
+        while self._accumulator + 1e-12 >= self.tick_duration:
+            self.clock.advance()
+            handler(self.clock.current_tick(), self.rng)
+            self._accumulator -= self.tick_duration
+            processed += 1
+        return processed
+
+    def step(self, handler: TickHandler) -> int:
+        """Sample the time source once and process any accumulated ticks."""
+
+        now = self.time_source()
+        delta = max(0.0, now - self._last_time)
+        self._last_time = now
+        return self.advance_by(delta, handler)
+
+    def run(self, ticks: int, handler: TickHandler) -> None:
+        """Run the loop until ``ticks`` iterations have been processed."""
+
+        if ticks < 0:
+            msg = "TickLoop cannot run a negative number of ticks"
+            raise ValueError(msg)
+        processed = 0
+        while processed < ticks:
+            processed += self.step(handler)
+            if processed < ticks and self._accumulator < self.tick_duration:
+                remaining = self.tick_duration - self._accumulator
+                self.sleep(remaining)

--- a/sim/src/ki_dev_tycoon/core/time.py
+++ b/sim/src/ki_dev_tycoon/core/time.py
@@ -13,6 +13,11 @@ class TimeProvider:
 
         raise NotImplementedError
 
+    def advance(self, steps: int = 1) -> int:
+        """Advance the provider by ``steps`` ticks and return the new tick."""
+
+        raise NotImplementedError
+
 
 @dataclass(slots=True)
 class TickClock(TimeProvider):
@@ -45,3 +50,8 @@ class FrozenTime(TimeProvider):
         """Return the frozen tick value without modification."""
 
         return self.tick
+
+    def advance(self, steps: int = 1) -> int:
+        """Frozen time cannot advance; raising an explicit error."""
+
+        raise ValueError("FrozenTime cannot advance")

--- a/sim/src/ki_dev_tycoon/persistence/__init__.py
+++ b/sim/src/ki_dev_tycoon/persistence/__init__.py
@@ -2,9 +2,10 @@
 
 from __future__ import annotations
 
-from .savegame import (
-    SaveGame,
-    SaveGameError,
+from ki_dev_tycoon.persistence.errors import SaveGameError
+from ki_dev_tycoon.persistence.savegame import (
+    GameStateModel,
+    SavegameModel,
     decode_savegame,
     encode_savegame,
     load_game,
@@ -12,7 +13,8 @@ from .savegame import (
 )
 
 __all__ = [
-    "SaveGame",
+    "GameStateModel",
+    "SavegameModel",
     "SaveGameError",
     "decode_savegame",
     "encode_savegame",

--- a/sim/src/ki_dev_tycoon/persistence/errors.py
+++ b/sim/src/ki_dev_tycoon/persistence/errors.py
@@ -1,0 +1,9 @@
+"""Custom exceptions for persistence modules."""
+
+from __future__ import annotations
+
+
+class SaveGameError(RuntimeError):
+    """Raised when a savegame cannot be parsed or validated."""
+
+    pass

--- a/sim/src/ki_dev_tycoon/persistence/migrations.py
+++ b/sim/src/ki_dev_tycoon/persistence/migrations.py
@@ -1,0 +1,25 @@
+"""Savegame migration helpers."""
+
+from __future__ import annotations
+
+from typing import Any, Mapping
+
+from ki_dev_tycoon.persistence.errors import SaveGameError
+
+CURRENT_VERSION = 1
+
+
+def migrate_payload(payload: Mapping[str, Any]) -> Mapping[str, Any]:
+    """Validate and migrate ``payload`` to the current savegame schema."""
+
+    try:
+        version = int(payload["version"])
+    except (KeyError, TypeError, ValueError) as exc:
+        msg = "Savegame payload is missing a valid version field"
+        raise SaveGameError(msg) from exc
+
+    if version != CURRENT_VERSION:
+        msg = f"Unsupported savegame version: {version}"
+        raise SaveGameError(msg)
+
+    return payload

--- a/sim/tests/unit/core/test_tick_loop.py
+++ b/sim/tests/unit/core/test_tick_loop.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+import math
+from collections import deque
+from typing import Deque, List
+
+import pytest
+from hypothesis import given, strategies as st
+
+from ki_dev_tycoon.core.loop import TickLoop
+from ki_dev_tycoon.core.rng import RandomSource
+from ki_dev_tycoon.core.time import TickClock
+
+
+def test_tick_loop_runs_requested_ticks() -> None:
+    """The loop should process ticks using the configured time source."""
+
+    samples: Deque[float] = deque([0.0, 0.5, 1.0, 1.5])
+
+    def time_source() -> float:
+        return samples.popleft()
+
+    processed: List[int] = []
+    loop = TickLoop(
+        clock=TickClock(),
+        rng=RandomSource(seed=1),
+        time_source=time_source,
+        sleep=lambda _: None,
+    )
+
+    loop.run(3, lambda tick, _: processed.append(tick))
+
+    assert processed == [1, 2, 3]
+
+
+def test_tick_loop_rejects_negative_delta() -> None:
+    clock = TickClock()
+    loop = TickLoop(clock=clock, rng=RandomSource(seed=2))
+
+    with pytest.raises(ValueError):
+        loop.advance_by(-0.1, lambda *_: None)
+
+
+@given(st.lists(st.floats(min_value=0.0, max_value=1.5), min_size=1, max_size=25))
+def test_tick_loop_tick_count_matches_elapsed(deltas: List[float]) -> None:
+    clock = TickClock()
+    rng = RandomSource(seed=42)
+    loop = TickLoop(clock=clock, rng=rng)
+
+    total_elapsed = 0.0
+    processed = 0
+
+    for delta in deltas:
+        processed += loop.advance_by(delta, lambda *_: None)
+        total_elapsed += delta
+
+    expected_ticks = math.floor(total_elapsed / loop.tick_duration)
+    assert clock.current_tick() == expected_ticks
+    assert processed == expected_ticks
+
+
+@given(
+    st.integers(min_value=0, max_value=2**32 - 1),
+    st.lists(st.floats(min_value=0.0, max_value=2.0), min_size=1, max_size=20),
+)
+def test_tick_loop_rng_stream_is_deterministic(seed: int, deltas: List[float]) -> None:
+    def run_once() -> List[float]:
+        clock = TickClock()
+        rng = RandomSource(seed=seed)
+        loop = TickLoop(clock=clock, rng=rng)
+        samples: List[float] = []
+        for delta in deltas:
+            loop.advance_by(delta, lambda _tick, source: samples.append(source.random()))
+        return samples
+
+    first = run_once()
+    second = run_once()
+
+    assert first == second

--- a/sim/tests/unit/test_rng.py
+++ b/sim/tests/unit/test_rng.py
@@ -1,4 +1,5 @@
 import pytest
+from hypothesis import given, strategies as st
 
 from ki_dev_tycoon.core.rng import RandomSource
 
@@ -40,3 +41,19 @@ def test_random_source_choice_requires_values() -> None:
 
     with pytest.raises(ValueError):
         rng.choice([])
+
+
+@given(
+    st.integers(min_value=0, max_value=2**32 - 1),
+    st.integers(min_value=0, max_value=10),
+    st.integers(min_value=1, max_value=5),
+)
+def test_random_source_randint_property(seed: int, lower: int, span: int) -> None:
+    upper = lower + span
+    rng_a = RandomSource(seed=seed)
+    rng_b = RandomSource(seed=seed)
+
+    draws_a = [rng_a.randint(lower, upper) for _ in range(10)]
+    draws_b = [rng_b.randint(lower, upper) for _ in range(10)]
+
+    assert draws_a == draws_b

--- a/sim/tests/unit/test_savegame.py
+++ b/sim/tests/unit/test_savegame.py
@@ -3,11 +3,13 @@ from __future__ import annotations
 from pathlib import Path
 
 import pytest
+import zstandard as zstd
 
 from ki_dev_tycoon.core.state import GameState
-from ki_dev_tycoon.persistence.savegame import (
-    SaveGame,
+from ki_dev_tycoon.persistence import (
+    GameStateModel,
     SaveGameError,
+    SavegameModel,
     decode_savegame,
     encode_savegame,
     load_game,
@@ -17,7 +19,7 @@ from ki_dev_tycoon.persistence.savegame import (
 
 def test_savegame_roundtrip(tmp_path: Path) -> None:
     state = GameState(tick=7, cash=250.5, reputation=60.0)
-    target = tmp_path / "save.json"
+    target = tmp_path / "save.zst"
 
     save_game(target, state)
     loaded = load_game(target)
@@ -27,15 +29,37 @@ def test_savegame_roundtrip(tmp_path: Path) -> None:
 
 def test_encode_and_decode_are_inverse_operations() -> None:
     state = GameState(tick=1, cash=0.0, reputation=50.0)
-    save = SaveGame(state=state)
+    save = SavegameModel.from_state(state)
 
     serialised = encode_savegame(save)
     decoded = decode_savegame(serialised)
 
-    assert decoded.state == state
+    assert decoded.state == GameStateModel.from_state(state)
     assert decoded.version == save.version
 
 
 def test_decode_savegame_rejects_invalid_payload() -> None:
     with pytest.raises(SaveGameError):
-        decode_savegame("{}")
+        decode_savegame(b"not a valid zstd stream")
+
+
+def test_decode_savegame_rejects_invalid_json() -> None:
+    save = SavegameModel.from_state(GameState(tick=1, cash=0.0, reputation=50.0))
+    payload = encode_savegame(save)
+    raw = zstd.ZstdDecompressor().decompress(payload).decode("utf-8")
+    corrupted = raw.replace("50.0", '"oops"', 1)
+    broken_payload = zstd.ZstdCompressor().compress(corrupted.encode("utf-8"))
+
+    with pytest.raises(SaveGameError):
+        decode_savegame(broken_payload)
+
+
+def test_migrate_rejects_unknown_version() -> None:
+    corrupt = SavegameModel(
+        version=999,
+        state=GameStateModel.from_state(GameState(tick=0, cash=0.0, reputation=50.0)),
+    )
+    payload = encode_savegame(corrupt)
+
+    with pytest.raises(SaveGameError):
+        decode_savegame(payload)

--- a/sim/tests/unit/test_time.py
+++ b/sim/tests/unit/test_time.py
@@ -1,4 +1,5 @@
 import pytest
+from hypothesis import given, strategies as st
 
 from ki_dev_tycoon.core.time import FrozenTime, TickClock
 
@@ -25,3 +26,13 @@ def test_frozen_time_returns_constant_tick() -> None:
     assert frozen.current_tick() == 42
     # Frozen time providers never change, even if tick would be modified elsewhere.
     assert frozen.current_tick() == 42
+
+
+@given(st.lists(st.integers(min_value=0, max_value=5), min_size=1, max_size=20))
+def test_tick_clock_advances_by_variable_steps(steps: list[int]) -> None:
+    clock = TickClock()
+    total = 0
+    for step in steps:
+        clock.advance(step)
+        total += step
+    assert clock.current_tick() == total


### PR DESCRIPTION
## Summary
- replace the argparse-based simulation CLI with a Typer module while keeping `ki_dev_tycoon.app` as the execution layer
- add a reusable TickLoop with a 0.5 s accumulator, injectable providers, and accompanying property tests
- migrate savegame persistence to Pydantic models with zstd compression and scaffold migrations alongside new pre-commit tooling and docs updates

## Testing
- poetry run pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68e534a0ef4c83279cc13b2ee4f4197f