### PR TITLE
feat: add textual ui shell with workspace support

### DIFF
--- a/app/README.md
+++ b/app/README.md
@@ -54,7 +54,20 @@ app/
 
 - **Entwicklungsmodus:** `poetry run ki-ui dev` → startet Textual-App mit Hot-Reload.
 - **Spielmodus:** `poetry run ki-ui play --save-slot 1` → lädt Savegame und startet den Sim-Loop.
-- **Headless-Autoplay:** `poetry run ki-ui autoplay --days 365 --seed 42` → nutzt Textual Dummy-Driver für automatisierte Tests.
+- **Headless-Autoplay:** `poetry run ki-ui autoplay --ticks 365 --seed 42` → nutzt Textual Dummy-Driver für automatisierte Tests.
+
+### Navigationsstruktur & Dialoge
+
+Die Textual-App stellt sechs Hauptbereiche bereit, die über eine horizontale Navigationsleiste (oder via Tastenkürzel `1`–`6`) erreichbar sind:
+
+1. **Dashboard** – KPI-Panel, Zeitreihenübersicht und Eventlog.
+2. **Team** – Rollenübersicht, Skill-Level sowie Recruiting-Events.
+3. **Forschung** – Aktiver Forschungsknoten, Fortschritt und Backlog.
+4. **Produkte** – Portfolio-Metriken, Durchschnittsqualität und Ereignisse.
+5. **Markt** – Segment-Adoption, TAM und Nachfragekennzahlen.
+6. **Events** – Chronologisches Log der Simulation.
+
+Mit `Ctrl+P` öffnet sich der Theme-Dialog. Hier können Light/Dark-Mode und ein farbenblindenfreundlicher Akzentmodus umgeschaltet werden. Änderungen werden sofort auf alle Screens angewendet.
 
 ## Build Pipeline
 
@@ -76,6 +89,8 @@ Das Skript kapselt alle Schritte (Assets bündeln, virtuelle Env einbetten, Stea
 - **mypy:** `poetry run mypy app/src`
 - **Linting:** `poetry run ruff check app/src app/tests`
 - **UI-Recording:** `poetry run ki-ui record --script scripts/demo_script.yaml`
+
+Die Snapshot-Tests verwenden `textual.testing` und vergleichen das KPI-Panel mit einem gespeicherten Referenz-Rendering (`app/tests/__snapshots__/dashboard_kpis.txt`). Bei UI-Änderungen kann der Snapshot über `poetry run pytest app/tests --snapshot-update` aktualisiert werden.
 
 ## Lokale API (optional)
 

--- a/app/pyproject.toml
+++ b/app/pyproject.toml
@@ -1,0 +1,41 @@
+[tool.poetry]
+name = "ki-dev-tycoon-ui"
+version = "0.1.0"
+description = "Textual-based user interface for the KI Dev Tycoon simulation."
+authors = ["KI Dev Tycoon Team <dev@ki-dev-tycoon.example>"]
+readme = "README.md"
+packages = [{ include = "ki_dev_tycoon", from = "src" }]
+
+[tool.poetry.dependencies]
+python = "^3.11"
+textual = "^0.58.1"
+rich = "^13.9.1"
+typer = "^0.12.5"
+httpx = "^0.27.2"
+ki-dev-tycoon = { path = "../sim", develop = true }
+
+[tool.poetry.group.dev.dependencies]
+pytest = "^8.3.3"
+pytest-asyncio = "^0.23.8"
+textual-dev = "^1.2.1"
+
+[tool.poetry.scripts]
+ki-ui = "ki_dev_tycoon.cli.ui_commands:app"
+
+[tool.mypy]
+python_version = "3.11"
+strict = true
+packages = ["ki_dev_tycoon"]
+
+[tool.black]
+line-length = 88
+
+[tool.isort]
+profile = "black"
+
+[tool.ruff]
+line-length = 88
+
+[build-system]
+requires = ["poetry-core>=1.8.0"]
+build-backend = "poetry.core.masonry.api"

--- a/app/src/ki_dev_tycoon/__init__.py
+++ b/app/src/ki_dev_tycoon/__init__.py
@@ -1,0 +1,27 @@
+"""UI package extensions for the KI Dev Tycoon simulation kernel."""
+
+from __future__ import annotations
+
+from importlib import metadata
+from pkgutil import extend_path
+
+__path__ = extend_path(__path__, __name__)
+__all__ = ["__version__"]
+
+try:  # pragma: no cover - query kernel package metadata if installed
+    _kernel_version = metadata.version("ki-dev-tycoon")
+except metadata.PackageNotFoundError:  # pragma: no cover - editable installs
+    _kernel_version = None
+
+try:  # pragma: no cover - query UI package metadata if available
+    _ui_version = metadata.version("ki-dev-tycoon-ui")
+except metadata.PackageNotFoundError:  # pragma: no cover - editable installs
+    if _kernel_version is None:
+        __version__ = "0.0.0"
+    else:
+        __version__ = f"{_kernel_version}+ui"
+else:
+    if _kernel_version:
+        __version__ = f"{_kernel_version}+ui"
+    else:
+        __version__ = _ui_version

--- a/app/src/ki_dev_tycoon/cli/__init__.py
+++ b/app/src/ki_dev_tycoon/cli/__init__.py
@@ -1,0 +1,5 @@
+"""CLI entrypoint grouping for the UI commands."""
+
+from .ui_commands import app
+
+__all__ = ["app"]

--- a/app/src/ki_dev_tycoon/cli/ui_commands.py
+++ b/app/src/ki_dev_tycoon/cli/ui_commands.py
@@ -1,0 +1,61 @@
+"""Typer-based CLI commands for launching the Textual UI."""
+
+from __future__ import annotations
+
+import typer
+
+from ki_dev_tycoon.ui.app import TycoonApp
+from ki_dev_tycoon.ui.presenter import SimulationPresenter, SimulationPresenterConfig
+
+
+app = typer.Typer(help="Launch the KI Dev Tycoon Textual client.")
+
+
+def _run_ui(config: SimulationPresenterConfig, *, headless: bool = False) -> None:
+    presenter = SimulationPresenter(config)
+    tycoon_app = TycoonApp(presenter=presenter)
+    tycoon_app.run(headless=headless)
+
+
+@app.command()
+def dev(
+    ticks: int = typer.Option(30, help="Number of ticks to simulate for the dashboard."),
+    seed: int = typer.Option(42, help="Deterministic simulation seed."),
+) -> None:
+    """Launch the UI with a local simulation in development mode."""
+
+    config = SimulationPresenterConfig(ticks=ticks, seed=seed, source="simulation")
+    _run_ui(config)
+
+
+@app.command()
+def play(
+    api_url: str = typer.Option(
+        "http://127.0.0.1:8765",
+        "--api-url",
+        help="Endpoint of a running FastAPI backend.",
+    ),
+    ticks: int = typer.Option(30, help="Fallback simulation ticks if API is unavailable."),
+    seed: int = typer.Option(42, help="Fallback simulation seed."),
+) -> None:
+    """Connect to the FastAPI backend or fall back to a local simulation."""
+
+    config = SimulationPresenterConfig(
+        ticks=ticks,
+        seed=seed,
+        api_url=api_url,
+        source="api",
+    )
+    _run_ui(config)
+
+
+@app.command()
+def autoplay(
+    ticks: int = typer.Option(60, help="Number of ticks for the automated run."),
+    seed: int = typer.Option(42, help="Deterministic simulation seed."),
+) -> None:
+    """Run the UI headlessly using Textual's dummy driver for automation."""
+
+    config = SimulationPresenterConfig(ticks=ticks, seed=seed, source="simulation")
+    _run_ui(config, headless=True)
+

--- a/app/src/ki_dev_tycoon/ui/__init__.py
+++ b/app/src/ki_dev_tycoon/ui/__init__.py
@@ -1,0 +1,5 @@
+"""Textual UI components for KI Dev Tycoon."""
+
+from .app import TycoonApp
+
+__all__ = ["TycoonApp"]

--- a/app/src/ki_dev_tycoon/ui/app.py
+++ b/app/src/ki_dev_tycoon/ui/app.py
@@ -1,0 +1,117 @@
+"""Main Textual application entry point."""
+
+from __future__ import annotations
+
+import logging
+from typing import Dict
+
+from textual.app import App
+from textual.binding import Binding
+from textual.events import Mount
+
+from .presenter import SimulationPresenter, SimulationPresenterConfig
+from .theme import ThemeController
+from .viewmodels import UiState
+from .widgets import NavItem
+from .screens import (
+    DashboardScreen,
+    EventsScreen,
+    MarketScreen,
+    ProductsScreen,
+    ResearchScreen,
+    TeamScreen,
+)
+from .screens.base import BaseScreen
+from .screens.settings import SettingsDialog
+
+
+NAV_ITEMS: tuple[NavItem, ...] = (
+    NavItem("dashboard", "Dashboard", "1"),
+    NavItem("team", "Team", "2"),
+    NavItem("research", "Forschung", "3"),
+    NavItem("products", "Produkte", "4"),
+    NavItem("market", "Markt", "5"),
+    NavItem("events", "Events", "6"),
+)
+
+
+class TycoonApp(App[None]):
+    """Textual front-end for the KI Dev Tycoon simulation."""
+
+    CSS_PATH = "app.tcss"
+    TITLE = "KI Dev Tycoon UI"
+    BINDINGS = [
+        Binding("1", "navigate('dashboard')", "Dashboard"),
+        Binding("2", "navigate('team')", "Team"),
+        Binding("3", "navigate('research')", "Forschung"),
+        Binding("4", "navigate('products')", "Produkte"),
+        Binding("5", "navigate('market')", "Markt"),
+        Binding("6", "navigate('events')", "Events"),
+        Binding("ctrl+r", "refresh", "Aktualisieren"),
+        Binding("ctrl+p", "open_settings", "Einstellungen"),
+        Binding("q", "quit", "Beenden"),
+    ]
+
+    def __init__(
+        self,
+        *,
+        presenter: SimulationPresenter | None = None,
+        theme_controller: ThemeController | None = None,
+        config: SimulationPresenterConfig | None = None,
+    ) -> None:
+        super().__init__()
+        self._logger = logging.getLogger(__name__)
+        self.presenter = presenter or SimulationPresenter(config)
+        self.theme_controller = theme_controller or ThemeController()
+        self._state: UiState | None = None
+        self._screens: Dict[str, BaseScreen] = {}
+
+    async def on_mount(self, event: Mount) -> None:
+        del event
+        nav_items = NAV_ITEMS
+        self._screens = {
+            "dashboard": DashboardScreen(nav_items),
+            "team": TeamScreen(nav_items),
+            "research": ResearchScreen(nav_items),
+            "products": ProductsScreen(nav_items),
+            "market": MarketScreen(nav_items),
+            "events": EventsScreen(nav_items),
+        }
+        for screen_id, screen in self._screens.items():
+            self.install_screen(screen, screen_id)
+        self.switch_screen("dashboard")
+        self.theme_controller.apply(self, self.theme_controller.settings)
+        await self._refresh_state()
+
+    async def _refresh_state(self) -> None:
+        self._set_status("Simulation wird geladen…")
+        try:
+            state = await self.presenter.build_ui_state()
+        except Exception:  # pragma: no cover - safeguard for UI experiments
+            self._logger.exception("Failed to build UI state")
+            self._set_status("Ladevorgang fehlgeschlagen")
+            return
+        self._state = state
+        for screen in self._screens.values():
+            screen.update_view(state)
+        latest_tick = self.presenter.latest_tick
+        status = f"Tick {latest_tick}" if latest_tick else ""
+        self._set_status(status or None)
+
+    def _set_status(self, status: str | None) -> None:
+        self.sub_title = status or ""
+
+    def action_navigate(self, screen_id: str) -> None:
+        if screen_id in self._screens:
+            self.switch_screen(screen_id)
+
+    async def action_refresh(self) -> None:
+        await self._refresh_state()
+
+    async def action_open_settings(self) -> None:
+        dialog = SettingsDialog(self.theme_controller.settings)
+        self.push_screen(dialog)
+
+    def on_settings_dialog_submitted(self, message: SettingsDialog.Submitted) -> None:
+        self.theme_controller.apply(self, message.settings)
+

--- a/app/src/ki_dev_tycoon/ui/app.tcss
+++ b/app/src/ki_dev_tycoon/ui/app.tcss
@@ -1,0 +1,26 @@
+Screen {
+    background: $panel;
+}
+
+#screen-layout {
+    padding: 1 2;
+    height: 1fr;
+    gap: 1;
+}
+
+#screen-content {
+    height: 1fr;
+    padding-top: 1;
+}
+
+NavigationBar > Horizontal {
+    gap: 1;
+}
+
+.colorblind-mode NavigationBar Button {
+    border: solid $warning;
+}
+
+.colorblind-mode KpiPanel Table {
+    border: solid $warning;
+}

--- a/app/src/ki_dev_tycoon/ui/presenter.py
+++ b/app/src/ki_dev_tycoon/ui/presenter.py
@@ -1,0 +1,510 @@
+"""Presenter layer bridging the simulation core with the Textual UI."""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, Literal, Sequence
+
+import httpx
+
+from ki_dev_tycoon.core.events import (
+    EventBus,
+    SimulationCompleted,
+    SimulationStarted,
+    TickProcessed,
+)
+from ki_dev_tycoon.core.rng import RandomSource
+from ki_dev_tycoon.core.state import GameState, ProductState, ResearchState, TeamMember, TeamState
+from ki_dev_tycoon.core.time import TickClock
+from ki_dev_tycoon.data.loader import AssetBundle, load_assets
+from ki_dev_tycoon.economy import project_adoption
+from ki_dev_tycoon.products import compute_quality
+from ki_dev_tycoon.research import progress_research
+from ki_dev_tycoon.team import ensure_minimum_staff, train_team
+
+from .viewmodels import (
+    DashboardViewModel,
+    EventLogEntry,
+    KpiSnapshot,
+    MarketViewModel,
+    ProductViewModel,
+    ResearchNodeViewModel,
+    ResearchViewModel,
+    TeamMemberViewModel,
+    TeamViewModel,
+    UiState,
+)
+
+
+@dataclass(slots=True, frozen=True)
+class SimulationPresenterConfig:
+    """Configuration passed to :class:`SimulationPresenter`."""
+
+    ticks: int = 30
+    seed: int = 42
+    daily_active_users: int = 5_000
+    arp_dau: float = 0.12
+    operating_costs: float = 450.0
+    asset_root: Path | None = None
+    api_url: str | None = None
+    source: Literal["simulation", "api"] = "simulation"
+
+
+class SimulationPresenter:
+    """Aggregate simulation data for the Textual UI."""
+
+    def __init__(self, config: SimulationPresenterConfig | None = None) -> None:
+        self.config = config or SimulationPresenterConfig()
+        self._event_bus = EventBus()
+        self._event_bus.subscribe(TickProcessed, self._record_tick)
+        self._observed_ticks: list[int] = []
+
+    @property
+    def event_bus(self) -> EventBus:
+        """Expose the underlying event bus for external subscribers."""
+
+        return self._event_bus
+
+    @property
+    def latest_tick(self) -> int:
+        """Return the highest tick observed while running the simulation."""
+
+        return self._observed_ticks[-1] if self._observed_ticks else 0
+
+    async def build_ui_state(self) -> UiState:
+        """Return the :class:`UiState` according to the configured source."""
+
+        if self.config.source == "api" and self.config.api_url:
+            try:
+                return await self._fetch_from_api(self.config.api_url)
+            except httpx.HTTPError:
+                # Fallback to local simulation if the API is unreachable.
+                pass
+        return await asyncio.to_thread(self._simulate_locally)
+
+    def _simulate_locally(self) -> UiState:
+        config = self.config
+        assets = load_assets(self._resolve_asset_root(config.asset_root))
+        clock = TickClock()
+        rng = RandomSource(config.seed)
+        self._event_bus.publish(SimulationStarted(seed=config.seed))
+
+        products = tuple(
+            ProductState(
+                product_id=product.id,
+                quality=product.base_quality,
+                adoption=0,
+                price=product.base_price,
+            )
+            for product in assets.products.values()
+        )
+        research_state = ResearchState(
+            unlocked=frozenset(),
+            active=None,
+            progress=0.0,
+            backlog=tuple(sorted(assets.research)),
+        )
+        state = GameState(
+            tick=clock.current_tick(),
+            cash=0.0,
+            reputation=50.0,
+            team=TeamState(members=()),
+            products=products,
+            research=research_state,
+        )
+
+        history: list[KpiSnapshot] = []
+        events: list[EventLogEntry] = []
+
+        for _ in range(config.ticks):
+            clock.advance()
+            state = state.advance_tick(clock)
+            tick_rng = rng.namespaced(f"tick:{state.tick}")
+            self._event_bus.publish(TickProcessed(tick=state.tick))
+
+            state, hired = self._ensure_staffing(state, assets, tick_rng)
+            quality_bonus, demand_bonus, training_bonus = self._aggregate_research_bonuses(
+                state.research, assets
+            )
+            state = self._train_team(state, assets, training_bonus)
+            state, completed_nodes = self._advance_research(state, assets)
+            if completed_nodes:
+                quality_bonus, demand_bonus, training_bonus = self._aggregate_research_bonuses(
+                    state.research, assets
+                )
+            state, event_entry, demand_multiplier, quality_penalty, reputation_bonus = self._apply_event(
+                state, assets, tick_rng
+            )
+            if event_entry is not None:
+                events.append(event_entry)
+            if reputation_bonus:
+                state = state.apply_reputation_delta(reputation_bonus)
+
+            state, revenue = self._update_products(
+                state,
+                assets,
+                tick_rng,
+                quality_bonus=quality_bonus,
+                demand_bonus=demand_bonus,
+                demand_multiplier=demand_multiplier,
+                quality_penalty=quality_penalty,
+            )
+
+            salary_cost = sum(assets.roles[member.role_id].salary for member in state.team.members)
+            cash_delta = revenue - salary_cost - config.operating_costs
+            state = state.apply_cash_delta(cash_delta)
+
+            direction = 1 if cash_delta >= 0 else -1
+            jitter = (tick_rng.random() - 0.5) * 0.2
+            state = state.apply_reputation_delta(direction * 0.5 + jitter)
+
+            total_adoption = sum(product.adoption for product in state.products)
+            avg_quality = (
+                sum(product.quality for product in state.products) / len(state.products)
+                if state.products
+                else 0.0
+            )
+            history.append(
+                KpiSnapshot(
+                    tick=state.tick,
+                    cash=state.cash,
+                    reputation=state.reputation,
+                    revenue=revenue,
+                    adoption=total_adoption,
+                    avg_quality=avg_quality,
+                    cash_delta=cash_delta,
+                )
+            )
+
+            if completed_nodes:
+                completion_text = ", ".join(completed_nodes)
+                events.append(
+                    EventLogEntry(
+                        tick=state.tick,
+                        name="Research breakthrough",
+                        description=f"Unlocked: {completion_text}",
+                    )
+                )
+            if hired:
+                events.append(
+                    EventLogEntry(
+                        tick=state.tick,
+                        name="New hires",
+                        description=f"Added {len(hired)} team members",
+                    )
+                )
+
+        self._event_bus.publish(SimulationCompleted(tick=state.tick))
+
+        dashboard = self._build_dashboard(history)
+        team = self._build_team_view(state.team, assets)
+        research = self._build_research_view(state.research, assets)
+        products_vm = self._build_product_view(state.products, assets)
+        markets = self._build_market_view(state.products, assets)
+
+        return UiState(
+            dashboard=dashboard,
+            team=team,
+            research=research,
+            products=products_vm,
+            markets=markets,
+            events=tuple(events[-40:]),
+        )
+
+    async def _fetch_from_api(self, base_url: str) -> UiState:
+        async with httpx.AsyncClient(base_url=base_url, timeout=5.0) as client:
+            response = await client.get("/state")
+            response.raise_for_status()
+            payload = response.json()
+
+        config = self.config
+        assets = load_assets(self._resolve_asset_root(config.asset_root))
+
+        average_quality = (
+            sum(float(project["quality"]) for project in payload["projects"])
+            / max(1, len(payload["projects"]))
+        )
+        history = (
+            KpiSnapshot(
+                tick=int(payload["tick"]),
+                cash=float(payload["cash"]),
+                reputation=float(payload["reputation"]),
+                revenue=config.daily_active_users * config.arp_dau,
+                adoption=sum(int(project["quality"] * 1_000) for project in payload["projects"]),
+                avg_quality=average_quality,
+                cash_delta=0.0,
+            ),
+        )
+        dashboard = self._build_dashboard(list(history))
+        team = TeamViewModel(members=())
+        research = self._build_research_view(
+            ResearchState(
+                unlocked=frozenset(),
+                active=None,
+                progress=0.0,
+                backlog=tuple(sorted(assets.research)),
+            ),
+            assets,
+        )
+        products_vm = self._build_product_view(tuple(), assets)
+        markets = self._build_market_view(tuple(), assets)
+        return UiState(
+            dashboard=dashboard,
+            team=team,
+            research=research,
+            products=products_vm,
+            markets=markets,
+            events=(
+                EventLogEntry(
+                    tick=int(payload["tick"]),
+                    name="API Snapshot",
+                    description="State retrieved from FastAPI backend",
+                ),
+            ),
+        )
+
+    def _build_dashboard(self, history: Sequence[KpiSnapshot]) -> DashboardViewModel:
+        latest = history[-1]
+        burn_rate = max(0.0, -latest.cash_delta)
+        return DashboardViewModel(
+            current_tick=latest.tick,
+            cash=latest.cash,
+            reputation=latest.reputation,
+            burn_rate=burn_rate,
+            daily_revenue=latest.revenue,
+            adoption=latest.adoption,
+            avg_quality=latest.avg_quality,
+            history=tuple(history),
+        )
+
+    def _build_team_view(self, team: TeamState, assets: AssetBundle) -> TeamViewModel:
+        members = tuple(
+            TeamMemberViewModel(
+                role_id=member.role_id,
+                role_name=assets.roles[member.role_id].name,
+                skill=member.skill,
+                training_progress=member.training_progress,
+                salary=assets.roles[member.role_id].salary,
+            )
+            for member in team.members
+        )
+        return TeamViewModel(members=members)
+
+    def _build_research_view(self, research: ResearchState, assets: AssetBundle) -> ResearchViewModel:
+        nodes = []
+        unlocked = set(research.unlocked)
+        backlog = set(research.backlog)
+        for node in sorted(assets.research.values(), key=lambda item: item.cost):
+            nodes.append(
+                ResearchNodeViewModel(
+                    node_id=node.id,
+                    name=node.name,
+                    cost=node.cost,
+                    unlocked=node.id in unlocked,
+                    in_backlog=node.id in backlog,
+                )
+            )
+        return ResearchViewModel(
+            active=research.active,
+            progress=research.progress,
+            unlocked=tuple(sorted(research.unlocked)),
+            backlog=tuple(research.backlog),
+            nodes=tuple(nodes),
+        )
+
+    def _build_product_view(
+        self, products: Iterable[ProductState], assets: AssetBundle
+    ) -> tuple[ProductViewModel, ...]:
+        view_models = []
+        for product in products:
+            config = assets.products.get(product.product_id)
+            if config is None:
+                continue
+            view_models.append(
+                ProductViewModel(
+                    product_id=product.product_id,
+                    name=config.name,
+                    market=assets.markets[config.target_market].name,
+                    price=product.price,
+                    quality=product.quality,
+                    adoption=product.adoption,
+                )
+            )
+        return tuple(view_models)
+
+    def _build_market_view(
+        self, products: Iterable[ProductState], assets: AssetBundle
+    ) -> tuple[MarketViewModel, ...]:
+        adoption_by_market: dict[str, int] = {market_id: 0 for market_id in assets.markets}
+        for product in products:
+            config = assets.products.get(product.product_id)
+            if config is None:
+                continue
+            adoption_by_market[config.target_market] += product.adoption
+        markets = []
+        for market_id, market in sorted(assets.markets.items()):
+            markets.append(
+                MarketViewModel(
+                    market_id=market_id,
+                    name=market.name,
+                    tam=market.tam,
+                    base_demand=market.base_demand,
+                    price_elasticity=market.price_elasticity,
+                    adoption=adoption_by_market.get(market_id, 0),
+                )
+            )
+        return tuple(markets)
+
+    def _ensure_staffing(
+        self, state: GameState, assets: AssetBundle, tick_rng: RandomSource
+    ) -> tuple[GameState, tuple[TeamMember, ...]]:
+        product_ids = tuple(product.product_id for product in state.products)
+        hiring_result = ensure_minimum_staff(
+            state.team,
+            assets=assets,
+            rng=tick_rng.namespaced(f"hiring:{state.tick}"),
+            product_ids=product_ids,
+        )
+        state = state.update_team(hiring_result.team)
+        return state, hiring_result.hired
+
+    def _train_team(
+        self, state: GameState, assets: AssetBundle, training_bonus: float
+    ) -> GameState:
+        training_result = train_team(
+            state.team,
+            assets=assets,
+            training_bonus=training_bonus,
+        )
+        return state.update_team(training_result.team)
+
+    def _advance_research(
+        self, state: GameState, assets: AssetBundle
+    ) -> tuple[GameState, tuple[str, ...]]:
+        research_points = self._compute_research_points(state.team)
+        progress_result = progress_research(
+            state.research,
+            assets=assets,
+            research_points=research_points,
+        )
+        state = state.update_research(progress_result.state)
+        return state, progress_result.completed
+
+    def _aggregate_research_bonuses(
+        self, research: ResearchState, assets: AssetBundle
+    ) -> tuple[float, float, float]:
+        quality_bonus = 0.0
+        demand_bonus = 0.0
+        training_bonus = 0.0
+        for node_id in research.unlocked:
+            node = assets.research.get(node_id)
+            if node is None:
+                continue
+            unlocks = node.unlocks
+            quality_bonus += unlocks.quality_bonus or 0.0
+            demand_bonus += unlocks.demand_bonus or 0.0
+            training_bonus += unlocks.training_bonus or 0.0
+        return quality_bonus, demand_bonus, training_bonus
+
+    def _apply_event(
+        self,
+        state: GameState,
+        assets: AssetBundle,
+        tick_rng: RandomSource,
+    ) -> tuple[GameState, EventLogEntry | None, float, float, float]:
+        events = sorted(assets.events.values(), key=lambda event: event.id)
+        total_weight = sum(event.weight for event in events)
+        if total_weight <= 0:
+            return state, None, 1.0, 0.0, 0.0
+        roll = tick_rng.namespaced(f"events:{state.tick}").random() * total_weight
+        accumulator = 0.0
+        selected = None
+        for event in events:
+            accumulator += event.weight
+            if roll <= accumulator:
+                selected = event
+                break
+        if selected is None:
+            return state, None, 1.0, 0.0, 0.0
+        demand_multiplier = selected.effects.get("demand_multiplier", 1.0)
+        quality_penalty = selected.effects.get("quality_penalty", 0.0)
+        reputation_bonus = selected.effects.get("reputation_bonus", 0.0)
+        effect_parts: list[str] = []
+        if demand_multiplier != 1.0:
+            effect_parts.append(f"Demand x{demand_multiplier:.2f}")
+        if quality_penalty:
+            effect_parts.append(f"Quality -{quality_penalty:.2f}")
+        if reputation_bonus:
+            effect_parts.append(f"Reputation +{reputation_bonus:.1f}")
+        description = ", ".join(effect_parts) if effect_parts else "No immediate effects"
+        entry = EventLogEntry(
+            tick=state.tick,
+            name=selected.name,
+            description=description,
+        )
+        return state, entry, demand_multiplier, quality_penalty, reputation_bonus
+
+    def _update_products(
+        self,
+        state: GameState,
+        assets: AssetBundle,
+        tick_rng: RandomSource,
+        *,
+        quality_bonus: float,
+        demand_bonus: float,
+        demand_multiplier: float,
+        quality_penalty: float,
+    ) -> tuple[GameState, float]:
+        total_revenue = 0.0
+        demand_rng = tick_rng.namespaced(f"demand:{state.tick}")
+        for product in state.products:
+            quality = compute_quality(
+                state,
+                product=product,
+                assets=assets,
+                research_quality_bonus=quality_bonus,
+            )
+            if quality_penalty:
+                quality = max(0.0, quality - quality_penalty)
+            updated_product = product.update_quality(quality)
+            adoption = project_adoption(
+                state,
+                product=updated_product,
+                assets=assets,
+                rng=demand_rng.namespaced(f"{product.product_id}:{state.tick}"),
+                demand_bonus=demand_bonus,
+                demand_multiplier=demand_multiplier,
+            )
+            updated_product = updated_product.update_adoption(adoption)
+            state = state.update_product(product.product_id, updated_product)
+            total_revenue += updated_product.adoption * updated_product.price
+        return state, total_revenue
+
+    def _compute_research_points(self, team: TeamState) -> float:
+        points = 0.0
+        for member in team.members:
+            if member.role_id == "data_scientist":
+                points += member.skill * 2.0
+            elif member.role_id == "engineer":
+                points += member.skill * 0.75
+            else:
+                points += member.skill * 0.25
+        return points
+
+    def _record_tick(self, event: TickProcessed) -> None:
+        self._observed_ticks.append(event.tick)
+
+    def _resolve_asset_root(self, configured: Path | None) -> Path:
+        if configured is not None:
+            return configured.expanduser().resolve()
+        search_root = Path(__file__).resolve()
+        for base in [search_root, *search_root.parents]:
+            candidate = base / "assets"
+            if candidate.is_dir():
+                return candidate
+        raise FileNotFoundError("Could not locate assets directory for UI presenter")
+
+
+__all__ = ["SimulationPresenter", "SimulationPresenterConfig"]

--- a/app/src/ki_dev_tycoon/ui/screens/__init__.py
+++ b/app/src/ki_dev_tycoon/ui/screens/__init__.py
@@ -1,0 +1,17 @@
+"""Screen exports for the Textual UI."""
+
+from .dashboard import DashboardScreen
+from .team import TeamScreen
+from .research import ResearchScreen
+from .products import ProductsScreen
+from .market import MarketScreen
+from .events import EventsScreen
+
+__all__ = [
+    "DashboardScreen",
+    "TeamScreen",
+    "ResearchScreen",
+    "ProductsScreen",
+    "MarketScreen",
+    "EventsScreen",
+]

--- a/app/src/ki_dev_tycoon/ui/screens/base.py
+++ b/app/src/ki_dev_tycoon/ui/screens/base.py
@@ -1,0 +1,54 @@
+"""Base classes for Textual screens."""
+
+from __future__ import annotations
+
+from abc import abstractmethod
+from typing import Iterable, Sequence
+
+from textual.app import ComposeResult
+from textual.containers import Container, Vertical
+from textual.events import Show
+from textual.screen import Screen
+from textual.widgets import Footer, Header
+
+from ..viewmodels import UiState
+from ..widgets import NavItem, NavigationBar
+
+
+class BaseScreen(Screen[UiState]):
+    """Common scaffolding for screens with navigation."""
+
+    def __init__(self, *, screen_id: str, title: str, nav_items: Sequence[NavItem]) -> None:
+        super().__init__(id=screen_id)
+        self._title = title
+        self._nav_items = tuple(nav_items)
+        self._navigation: NavigationBar | None = None
+        self.title = title
+
+    def compose(self) -> ComposeResult:
+        yield Header(show_clock=True)
+        with Vertical(id="screen-layout"):
+            self._navigation = NavigationBar(self._nav_items, active=self.id or "")
+            yield self._navigation
+            with Container(id="screen-content"):
+                yield from self.compose_content()
+        yield Footer()
+
+    @abstractmethod
+    def compose_content(self) -> Iterable[object]:
+        """Compose the screen specific content widgets."""
+
+    @abstractmethod
+    def update_view(self, state: UiState) -> None:
+        """Update the widgets using ``state``."""
+
+    def on_navigation_bar_nav_requested(self, message: NavigationBar.NavRequested) -> None:
+        message.stop()
+        if message.target != self.id:
+            self.app.action_navigate(message.target)
+
+    def on_show(self, event: Show) -> None:
+        del event
+        if self._navigation is not None:
+            self._navigation.set_active(self.id or "")
+

--- a/app/src/ki_dev_tycoon/ui/screens/dashboard.py
+++ b/app/src/ki_dev_tycoon/ui/screens/dashboard.py
@@ -1,0 +1,33 @@
+"""Dashboard screen definition."""
+
+from __future__ import annotations
+
+from textual.app import ComposeResult
+from textual.containers import Horizontal, Vertical
+
+from ..viewmodels import UiState
+from ..widgets import EventLog, KpiPanel, NavItem, Timeline
+from .base import BaseScreen
+
+
+class DashboardScreen(BaseScreen):
+    """High-level KPI overview."""
+
+    def __init__(self, nav_items: tuple[NavItem, ...]) -> None:
+        super().__init__(screen_id="dashboard", title="Dashboard", nav_items=nav_items)
+        self._kpi = KpiPanel()
+        self._timeline = Timeline(rows=12)
+        self._events = EventLog(rows=12)
+
+    def compose_content(self) -> ComposeResult:
+        with Vertical():
+            with Horizontal():
+                yield self._kpi
+                yield self._timeline
+            yield self._events
+
+    def update_view(self, state: UiState) -> None:
+        self._kpi.update_view(state.dashboard)
+        self._timeline.update_view(state.dashboard)
+        self._events.update_view(state.events)
+

--- a/app/src/ki_dev_tycoon/ui/screens/events.py
+++ b/app/src/ki_dev_tycoon/ui/screens/events.py
@@ -1,0 +1,31 @@
+"""Events screen implementation."""
+
+from __future__ import annotations
+
+from textual.app import ComposeResult
+from textual.containers import Vertical
+from textual.widgets import Static
+
+from ..viewmodels import UiState
+from ..widgets import EventLog, NavItem
+from .base import BaseScreen
+
+
+class EventsScreen(BaseScreen):
+    """Dedicated event timeline view."""
+
+    def __init__(self, nav_items: tuple[NavItem, ...]) -> None:
+        super().__init__(screen_id="events", title="Events", nav_items=nav_items)
+        self._hint = Static(
+            "Zeigt die letzten Spielereignisse und Simulationsturns an.", id="events-hint"
+        )
+        self._log = EventLog(rows=25)
+
+    def compose_content(self) -> ComposeResult:
+        with Vertical():
+            yield self._hint
+            yield self._log
+
+    def update_view(self, state: UiState) -> None:
+        self._log.update_view(state.events)
+

--- a/app/src/ki_dev_tycoon/ui/screens/market.py
+++ b/app/src/ki_dev_tycoon/ui/screens/market.py
@@ -1,0 +1,34 @@
+"""Market screen implementation."""
+
+from __future__ import annotations
+
+from textual.app import ComposeResult
+from textual.containers import Vertical
+from textual.widgets import Static
+
+from ..viewmodels import UiState
+from ..widgets import MarketTable, NavItem
+from .base import BaseScreen
+
+
+class MarketScreen(BaseScreen):
+    """Display market demand and adoption."""
+
+    def __init__(self, nav_items: tuple[NavItem, ...]) -> None:
+        super().__init__(screen_id="market", title="Markt", nav_items=nav_items)
+        self._summary = Static(id="market-summary")
+        self._markets = MarketTable()
+
+    def compose_content(self) -> ComposeResult:
+        with Vertical():
+            yield self._summary
+            yield self._markets
+
+    def update_view(self, state: UiState) -> None:
+        markets = state.markets
+        total_adoption = sum(market.adoption for market in markets)
+        self._summary.update(
+            f"Segmente: {len(markets)} · Gesamtadoption: {total_adoption:,d}"
+        )
+        self._markets.update_view(markets)
+

--- a/app/src/ki_dev_tycoon/ui/screens/products.py
+++ b/app/src/ki_dev_tycoon/ui/screens/products.py
@@ -1,0 +1,40 @@
+"""Products screen implementation."""
+
+from __future__ import annotations
+
+from textual.app import ComposeResult
+from textual.containers import Vertical
+from textual.widgets import Static
+
+from ..viewmodels import UiState
+from ..widgets import EventLog, NavItem, ProductTable
+from .base import BaseScreen
+
+
+class ProductsScreen(BaseScreen):
+    """Display portfolio metrics and related events."""
+
+    def __init__(self, nav_items: tuple[NavItem, ...]) -> None:
+        super().__init__(screen_id="products", title="Produkte", nav_items=nav_items)
+        self._products = ProductTable()
+        self._summary = Static(id="product-summary")
+        self._events = EventLog(rows=10)
+
+    def compose_content(self) -> ComposeResult:
+        with Vertical():
+            yield self._summary
+            yield self._products
+            yield self._events
+
+    def update_view(self, state: UiState) -> None:
+        products = state.products
+        total_adoption = sum(product.adoption for product in products)
+        average_quality = (
+            sum(product.quality for product in products) / len(products) if products else 0.0
+        )
+        self._summary.update(
+            f"Produkte: {len(products)} · Adoption: {total_adoption:,d} · Qualität: {average_quality:.2f}"
+        )
+        self._products.update_view(products)
+        self._events.update_view(state.events)
+

--- a/app/src/ki_dev_tycoon/ui/screens/research.py
+++ b/app/src/ki_dev_tycoon/ui/screens/research.py
@@ -1,0 +1,34 @@
+"""Research screen implementation."""
+
+from __future__ import annotations
+
+from textual.app import ComposeResult
+from textual.containers import Vertical
+from textual.widgets import Static
+
+from ..viewmodels import UiState
+from ..widgets import NavItem, ResearchTree
+from .base import BaseScreen
+
+
+class ResearchScreen(BaseScreen):
+    """Visualise research progress and backlog."""
+
+    def __init__(self, nav_items: tuple[NavItem, ...]) -> None:
+        super().__init__(screen_id="research", title="Forschung", nav_items=nav_items)
+        self._tree = ResearchTree()
+        self._status = Static(id="research-status")
+
+    def compose_content(self) -> ComposeResult:
+        with Vertical():
+            yield self._status
+            yield self._tree
+
+    def update_view(self, state: UiState) -> None:
+        research = state.research
+        active = research.active or "—"
+        self._status.update(
+            f"Aktiv: [bold]{active}[/bold] · Fortschritt: {research.progress:.0%} · Unlocked: {len(research.unlocked)}"
+        )
+        self._tree.update_view(research)
+

--- a/app/src/ki_dev_tycoon/ui/screens/settings.py
+++ b/app/src/ki_dev_tycoon/ui/screens/settings.py
@@ -1,0 +1,64 @@
+"""Modal dialog for theme settings."""
+
+from __future__ import annotations
+
+from textual.app import ComposeResult
+from textual.containers import Vertical
+from textual.message import Message
+from textual.screen import ModalScreen
+from textual.widgets import Button, Checkbox, Label, RadioButton, RadioSet
+
+from ..theme import ThemeSettings
+
+
+class SettingsDialog(ModalScreen[ThemeSettings | None]):
+    """Allow the user to change theme and accessibility options."""
+
+    CSS = """
+    SettingsDialog { align: center middle; }
+    #dialog { width: 48; padding: 1 2; border: tall $accent; }
+    #controls { padding-top: 1; }
+    #actions { padding-top: 1; }
+    """
+
+    class Submitted(Message):
+        """Emitted when the user confirms new settings."""
+
+        def __init__(self, sender: "SettingsDialog", settings: ThemeSettings) -> None:
+            super().__init__()
+            self.settings = settings
+            self._sender = sender
+
+        @property
+        def sender(self) -> "SettingsDialog":  # type: ignore[override]
+            return self._sender
+
+    def __init__(self, settings: ThemeSettings) -> None:
+        super().__init__()
+        self._settings = settings
+
+    def compose(self) -> ComposeResult:
+        with Vertical(id="dialog"):
+            yield Label("Darstellung", id="settings-title")
+            with RadioSet(id="controls", allow_no_selection=False):
+                yield RadioButton("Dunkles Theme", id="theme-dark", value=self._settings.mode == "dark")
+                yield RadioButton("Helles Theme", id="theme-light", value=self._settings.mode == "light")
+            yield Checkbox(
+                "Farbenblindfreundliche Akzente aktivieren",
+                id="colorblind",
+                value=self._settings.colorblind_friendly,
+            )
+            with Vertical(id="actions"):
+                yield Button("Übernehmen", id="apply", variant="primary")
+                yield Button("Abbrechen", id="cancel")
+
+    def on_button_pressed(self, event: Button.Pressed) -> None:
+        if event.button.id == "apply":
+            mode = "dark" if self.query_one("#theme-dark", RadioButton).value else "light"
+            colorblind = self.query_one("#colorblind", Checkbox).value
+            settings = ThemeSettings(mode=mode, colorblind_friendly=colorblind)
+            self.post_message(self.Submitted(self, settings))
+            self.dismiss(settings)
+        elif event.button.id == "cancel":
+            self.dismiss(None)
+

--- a/app/src/ki_dev_tycoon/ui/screens/team.py
+++ b/app/src/ki_dev_tycoon/ui/screens/team.py
@@ -1,0 +1,29 @@
+"""Team screen implementation."""
+
+from __future__ import annotations
+
+from textual.app import ComposeResult
+from textual.containers import Vertical
+
+from ..viewmodels import UiState
+from ..widgets import EventLog, NavItem, TeamTable
+from .base import BaseScreen
+
+
+class TeamScreen(BaseScreen):
+    """Display team composition and related events."""
+
+    def __init__(self, nav_items: tuple[NavItem, ...]) -> None:
+        super().__init__(screen_id="team", title="Team", nav_items=nav_items)
+        self._team = TeamTable()
+        self._events = EventLog(rows=15)
+
+    def compose_content(self) -> ComposeResult:
+        with Vertical():
+            yield self._team
+            yield self._events
+
+    def update_view(self, state: UiState) -> None:
+        self._team.update_view(state.team)
+        self._events.update_view(state.events)
+

--- a/app/src/ki_dev_tycoon/ui/theme.py
+++ b/app/src/ki_dev_tycoon/ui/theme.py
@@ -1,0 +1,51 @@
+"""Theme utilities for the Textual UI."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from textual.app import App
+
+
+@dataclass(slots=True, frozen=True)
+class ThemeSettings:
+    """User-configurable visual preferences."""
+
+    mode: str = "dark"
+    colorblind_friendly: bool = False
+
+    def toggle_mode(self) -> "ThemeSettings":
+        """Return a copy with ``mode`` flipped between light and dark."""
+
+        return ThemeSettings(
+            mode="light" if self.mode == "dark" else "dark",
+            colorblind_friendly=self.colorblind_friendly,
+        )
+
+    def toggle_colorblind(self) -> "ThemeSettings":
+        """Return a copy with the colorblind flag inverted."""
+
+        return ThemeSettings(
+            mode=self.mode,
+            colorblind_friendly=not self.colorblind_friendly,
+        )
+
+
+class ThemeController:
+    """Apply :class:`ThemeSettings` to a running :class:`~textual.app.App`."""
+
+    def __init__(self) -> None:
+        self._settings = ThemeSettings()
+
+    @property
+    def settings(self) -> ThemeSettings:
+        return self._settings
+
+    def apply(self, app: App, settings: ThemeSettings) -> None:
+        """Update ``app`` to match the provided ``settings``."""
+
+        self._settings = settings
+        app.dark = settings.mode == "dark"
+        if app.screen is not None:
+            app.screen.set_class(settings.colorblind_friendly, "colorblind-mode")
+

--- a/app/src/ki_dev_tycoon/ui/viewmodels.py
+++ b/app/src/ki_dev_tycoon/ui/viewmodels.py
@@ -1,0 +1,132 @@
+"""Immutable view models shared between Textual screens."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable
+
+
+@dataclass(slots=True, frozen=True)
+class KpiSnapshot:
+    """Key performance indicator values captured for a single tick."""
+
+    tick: int
+    cash: float
+    reputation: float
+    revenue: float
+    adoption: int
+    avg_quality: float
+    cash_delta: float
+
+
+@dataclass(slots=True, frozen=True)
+class DashboardViewModel:
+    """Aggregated dashboard data for the active simulation."""
+
+    current_tick: int
+    cash: float
+    reputation: float
+    burn_rate: float
+    daily_revenue: float
+    adoption: int
+    avg_quality: float
+    history: tuple[KpiSnapshot, ...]
+
+    def tail(self, count: int = 10) -> tuple[KpiSnapshot, ...]:
+        """Return the most recent ``count`` KPI snapshots."""
+
+        if count <= 0:
+            return ()
+        return self.history[-count:]
+
+
+@dataclass(slots=True, frozen=True)
+class TeamMemberViewModel:
+    """Lightweight representation of a staff member."""
+
+    role_id: str
+    role_name: str
+    skill: float
+    training_progress: float
+    salary: float
+
+
+@dataclass(slots=True, frozen=True)
+class TeamViewModel:
+    """Immutable team overview used by the team screen."""
+
+    members: tuple[TeamMemberViewModel, ...]
+
+    @property
+    def headcount(self) -> int:
+        return len(self.members)
+
+    def members_by_role(self, role_id: str) -> Iterable[TeamMemberViewModel]:
+        return tuple(member for member in self.members if member.role_id == role_id)
+
+
+@dataclass(slots=True, frozen=True)
+class ResearchNodeViewModel:
+    """Describes a single entry in the research tree."""
+
+    node_id: str
+    name: str
+    cost: int
+    unlocked: bool
+    in_backlog: bool
+
+
+@dataclass(slots=True, frozen=True)
+class ResearchViewModel:
+    """Aggregates the state of the research subsystem."""
+
+    active: str | None
+    progress: float
+    unlocked: tuple[str, ...]
+    backlog: tuple[str, ...]
+    nodes: tuple[ResearchNodeViewModel, ...]
+
+
+@dataclass(slots=True, frozen=True)
+class ProductViewModel:
+    """View model describing a product and its KPIs."""
+
+    product_id: str
+    name: str
+    market: str
+    price: float
+    quality: float
+    adoption: int
+
+
+@dataclass(slots=True, frozen=True)
+class MarketViewModel:
+    """Aggregated market information for the market screen."""
+
+    market_id: str
+    name: str
+    tam: int
+    base_demand: float
+    price_elasticity: float
+    adoption: int
+
+
+@dataclass(slots=True, frozen=True)
+class EventLogEntry:
+    """Represents a domain event shown in the event log."""
+
+    tick: int
+    name: str
+    description: str
+
+
+@dataclass(slots=True, frozen=True)
+class UiState:
+    """Complete UI state object consumed by the Textual app."""
+
+    dashboard: DashboardViewModel
+    team: TeamViewModel
+    research: ResearchViewModel
+    products: tuple[ProductViewModel, ...]
+    markets: tuple[MarketViewModel, ...]
+    events: tuple[EventLogEntry, ...]

--- a/app/src/ki_dev_tycoon/ui/widgets/__init__.py
+++ b/app/src/ki_dev_tycoon/ui/widgets/__init__.py
@@ -1,0 +1,22 @@
+"""Reusable UI widgets for the Textual client."""
+
+from .navigation import NavItem, NavigationBar
+from .kpi_panel import KpiPanel
+from .timeline import Timeline
+from .team_table import TeamTable
+from .product_table import ProductTable
+from .market_table import MarketTable
+from .event_log import EventLog
+from .research_tree import ResearchTree
+
+__all__ = [
+    "EventLog",
+    "KpiPanel",
+    "MarketTable",
+    "NavItem",
+    "NavigationBar",
+    "ProductTable",
+    "TeamTable",
+    "Timeline",
+    "ResearchTree",
+]

--- a/app/src/ki_dev_tycoon/ui/widgets/event_log.py
+++ b/app/src/ki_dev_tycoon/ui/widgets/event_log.py
@@ -1,0 +1,39 @@
+"""Event log widget."""
+
+from __future__ import annotations
+
+from typing import Iterable
+
+from rich.table import Table
+from textual.widget import Widget
+
+from ..viewmodels import EventLogEntry
+
+
+class EventLog(Widget):
+    """Render the recent simulation events."""
+
+    DEFAULT_CSS = "EventLog { width: 1fr; height: auto; padding: 0 1; }"
+
+    def __init__(self, *, rows: int = 12) -> None:
+        super().__init__()
+        self._rows = rows
+        self._events: tuple[EventLogEntry, ...] = ()
+
+    def update_view(self, events: Iterable[EventLogEntry]) -> None:
+        events_tuple = tuple(events)
+        self._events = events_tuple[-self._rows :]
+        self.refresh()
+
+    def render(self) -> Table:
+        table = Table(title="Event log", pad_edge=False)
+        table.add_column("Tick", justify="right")
+        table.add_column("Event", justify="left", style="bold")
+        table.add_column("Details", justify="left")
+        if not self._events:
+            table.add_row("–", "No events", "Simulation idle")
+            return table
+        for entry in self._events:
+            table.add_row(str(entry.tick), entry.name, entry.description)
+        return table
+

--- a/app/src/ki_dev_tycoon/ui/widgets/kpi_panel.py
+++ b/app/src/ki_dev_tycoon/ui/widgets/kpi_panel.py
@@ -1,0 +1,42 @@
+"""Dashboard KPI panel widget."""
+
+from __future__ import annotations
+
+from rich.table import Table
+from textual.widget import Widget
+
+from ..viewmodels import DashboardViewModel
+
+
+class KpiPanel(Widget):
+    """Render the primary company KPIs."""
+
+    DEFAULT_CSS = "KpiPanel { width: 1fr; height: auto; padding: 0 1; }"
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._dashboard: DashboardViewModel | None = None
+
+    def update_view(self, dashboard: DashboardViewModel) -> None:
+        """Store ``dashboard`` for the next render cycle."""
+
+        self._dashboard = dashboard
+        self.refresh()
+
+    def render(self) -> Table:
+        dashboard = self._dashboard
+        table = Table.grid(padding=(0, 1))
+        table.add_column("Metric", justify="left", style="bold")
+        table.add_column("Value", justify="right")
+        if dashboard is None:
+            table.add_row("Status", "Loading…")
+            return table
+        table.title = f"Tick {dashboard.current_tick}"  # type: ignore[assignment]
+        table.add_row("Cash", f"€{dashboard.cash:,.0f}")
+        table.add_row("Daily revenue", f"€{dashboard.daily_revenue:,.0f}")
+        table.add_row("Burn rate", f"€{dashboard.burn_rate:,.0f}")
+        table.add_row("Reputation", f"{dashboard.reputation:.1f}")
+        table.add_row("Total adoption", f"{dashboard.adoption:,d}")
+        table.add_row("Average quality", f"{dashboard.avg_quality:.2f}")
+        return table
+

--- a/app/src/ki_dev_tycoon/ui/widgets/market_table.py
+++ b/app/src/ki_dev_tycoon/ui/widgets/market_table.py
@@ -1,0 +1,45 @@
+"""Market overview widget."""
+
+from __future__ import annotations
+
+from typing import Iterable
+
+from rich.table import Table
+from textual.widget import Widget
+
+from ..viewmodels import MarketViewModel
+
+
+class MarketTable(Widget):
+    """Render market statistics."""
+
+    DEFAULT_CSS = "MarketTable { width: 1fr; height: auto; padding: 0 1; }"
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._markets: tuple[MarketViewModel, ...] = ()
+
+    def update_view(self, markets: Iterable[MarketViewModel]) -> None:
+        self._markets = tuple(markets)
+        self.refresh()
+
+    def render(self) -> Table:
+        table = Table(title="Markets", pad_edge=False)
+        table.add_column("Market", justify="left", style="bold")
+        table.add_column("TAM", justify="right")
+        table.add_column("Base demand", justify="right")
+        table.add_column("Price elasticity", justify="right")
+        table.add_column("Adoption", justify="right")
+        if not self._markets:
+            table.add_row("No markets", "–", "–", "–", "–")
+            return table
+        for market in self._markets:
+            table.add_row(
+                market.name,
+                f"{market.tam:,d}",
+                f"{market.base_demand:.2f}",
+                f"{market.price_elasticity:.2f}",
+                f"{market.adoption:,d}",
+            )
+        return table
+

--- a/app/src/ki_dev_tycoon/ui/widgets/navigation.py
+++ b/app/src/ki_dev_tycoon/ui/widgets/navigation.py
@@ -1,0 +1,77 @@
+"""Navigation widgets used by the Textual UI."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, Sequence
+
+from textual import events
+from textual.containers import Horizontal
+from textual.message import Message
+from textual.widget import Widget
+from textual.widgets import Button
+
+
+@dataclass(slots=True, frozen=True)
+class NavItem:
+    """Descriptor for a navigation button."""
+
+    screen_id: str
+    label: str
+    shortcut: str | None = None
+
+
+class NavigationBar(Widget):
+    """Horizontal navigation used to switch between screens."""
+
+    DEFAULT_CSS = "NavigationBar { height: auto; padding: 0 1; }"
+
+    class NavRequested(Message):
+        """Message emitted when the user selects a navigation target."""
+
+        def __init__(self, sender: NavigationBar, target: str) -> None:
+            super().__init__()
+            self.target = target
+            self._sender = sender
+
+        @property
+        def sender(self) -> NavigationBar:  # type: ignore[override]
+            return self._sender
+
+    def __init__(self, items: Sequence[NavItem], active: str) -> None:
+        super().__init__()
+        self._items = tuple(items)
+        self._active = active
+
+    def set_active(self, screen_id: str) -> None:
+        """Mark ``screen_id`` as active and update button variants."""
+
+        self._active = screen_id
+        for button in self.query(Button):
+            button.variant = "primary" if button.id == f"nav-{screen_id}" else "default"
+
+    def compose(self) -> Iterable[Widget]:  # type: ignore[override]
+        with Horizontal(id="nav-bar"):
+            for item in self._items:
+                label = item.label
+                if item.shortcut:
+                    label = f"{item.label} [{item.shortcut}]"
+                variant = "primary" if item.screen_id == self._active else "default"
+                yield Button(
+                    label,
+                    id=f"nav-{item.screen_id}",
+                    variant=variant,
+                )
+
+    def on_button_pressed(self, event: Button.Pressed) -> None:
+        target = event.button.id.replace("nav-", "", 1)
+        self.post_message(self.NavRequested(self, target))
+
+    def on_key(self, event: events.Key) -> None:
+        if not event.key:
+            return
+        for item in self._items:
+            if item.shortcut == event.key:
+                self.post_message(self.NavRequested(self, item.screen_id))
+                return
+

--- a/app/src/ki_dev_tycoon/ui/widgets/product_table.py
+++ b/app/src/ki_dev_tycoon/ui/widgets/product_table.py
@@ -1,0 +1,45 @@
+"""Product overview widget."""
+
+from __future__ import annotations
+
+from typing import Iterable
+
+from rich.table import Table
+from textual.widget import Widget
+
+from ..viewmodels import ProductViewModel
+
+
+class ProductTable(Widget):
+    """Display the current product portfolio."""
+
+    DEFAULT_CSS = "ProductTable { width: 1fr; height: auto; padding: 0 1; }"
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._products: tuple[ProductViewModel, ...] = ()
+
+    def update_view(self, products: Iterable[ProductViewModel]) -> None:
+        self._products = tuple(products)
+        self.refresh()
+
+    def render(self) -> Table:
+        table = Table(title="Products", pad_edge=False)
+        table.add_column("Name", justify="left", style="bold")
+        table.add_column("Market", justify="left")
+        table.add_column("Price", justify="right")
+        table.add_column("Quality", justify="right")
+        table.add_column("Adoption", justify="right")
+        if not self._products:
+            table.add_row("No products", "–", "–", "–", "–")
+            return table
+        for product in self._products:
+            table.add_row(
+                product.name,
+                product.market,
+                f"€{product.price:,.2f}",
+                f"{product.quality:.2f}",
+                f"{product.adoption:,d}",
+            )
+        return table
+

--- a/app/src/ki_dev_tycoon/ui/widgets/research_tree.py
+++ b/app/src/ki_dev_tycoon/ui/widgets/research_tree.py
@@ -1,0 +1,46 @@
+"""Research tree widget."""
+
+from __future__ import annotations
+
+from typing import Iterable
+
+from rich.table import Table
+from textual.widget import Widget
+
+from ..viewmodels import ResearchNodeViewModel, ResearchViewModel
+
+
+class ResearchTree(Widget):
+    """Display research backlog and unlocks."""
+
+    DEFAULT_CSS = "ResearchTree { width: 1fr; height: auto; padding: 0 1; }"
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._research: ResearchViewModel | None = None
+
+    def update_view(self, research: ResearchViewModel) -> None:
+        self._research = research
+        self.refresh()
+
+    def _render_nodes(self, nodes: Iterable[ResearchNodeViewModel]) -> Table:
+        table = Table(title="Research", pad_edge=False)
+        table.add_column("Node", justify="left", style="bold")
+        table.add_column("Cost", justify="right")
+        table.add_column("Status", justify="left")
+        for node in nodes:
+            status_parts: list[str] = []
+            if node.unlocked:
+                status_parts.append("Unlocked")
+            elif node.in_backlog:
+                status_parts.append("Queued")
+            else:
+                status_parts.append("Locked")
+            table.add_row(node.name, str(node.cost), ", ".join(status_parts))
+        return table
+
+    def render(self) -> Table:
+        if self._research is None:
+            return self._render_nodes(())
+        return self._render_nodes(self._research.nodes)
+

--- a/app/src/ki_dev_tycoon/ui/widgets/team_table.py
+++ b/app/src/ki_dev_tycoon/ui/widgets/team_table.py
@@ -1,0 +1,55 @@
+"""Team overview widget."""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from typing import Iterable
+
+from rich.table import Table
+from textual.widget import Widget
+
+from ..viewmodels import TeamMemberViewModel, TeamViewModel
+
+
+class TeamTable(Widget):
+    """Render the current team composition."""
+
+    DEFAULT_CSS = "TeamTable { width: 1fr; height: auto; padding: 0 1; }"
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._team: TeamViewModel | None = None
+
+    def update_view(self, team: TeamViewModel) -> None:
+        self._team = team
+        self.refresh()
+
+    def _aggregate(self, members: Iterable[TeamMemberViewModel]) -> Table:
+        table = Table(title="Team", pad_edge=False)
+        table.add_column("Role", justify="left", style="bold")
+        table.add_column("Headcount", justify="right")
+        table.add_column("Average skill", justify="right")
+        table.add_column("Salary / day", justify="right")
+
+        buckets: dict[str, list[TeamMemberViewModel]] = defaultdict(list)
+        for member in members:
+            buckets[member.role_name].append(member)
+        if not buckets:
+            table.add_row("No staff", "0", "–", "–")
+            return table
+        for role_name, bucket in sorted(buckets.items(), key=lambda item: item[0]):
+            average_skill = sum(member.skill for member in bucket) / len(bucket)
+            salary = sum(member.salary for member in bucket)
+            table.add_row(
+                role_name,
+                str(len(bucket)),
+                f"{average_skill:.2f}",
+                f"€{salary:,.0f}",
+            )
+        return table
+
+    def render(self) -> Table:
+        if self._team is None:
+            return self._aggregate(())
+        return self._aggregate(self._team.members)
+

--- a/app/src/ki_dev_tycoon/ui/widgets/timeline.py
+++ b/app/src/ki_dev_tycoon/ui/widgets/timeline.py
@@ -1,0 +1,48 @@
+"""Timeline widget for per-tick KPI history."""
+
+from __future__ import annotations
+
+from typing import Iterable
+
+from rich.table import Table
+from textual.widget import Widget
+
+from ..viewmodels import DashboardViewModel, KpiSnapshot
+
+
+class Timeline(Widget):
+    """Render the KPI history as a compact table."""
+
+    DEFAULT_CSS = "Timeline { width: 1fr; height: auto; padding: 0 1; }"
+
+    def __init__(self, *, rows: int = 10) -> None:
+        super().__init__()
+        self._dashboard: DashboardViewModel | None = None
+        self._rows = rows
+
+    def update_view(self, dashboard: DashboardViewModel) -> None:
+        self._dashboard = dashboard
+        self.refresh()
+
+    def _rows_for(self, history: Iterable[KpiSnapshot]) -> Table:
+        table = Table(title="Recent KPIs", pad_edge=False)
+        table.add_column("Tick", justify="right")
+        table.add_column("Cash", justify="right")
+        table.add_column("Revenue", justify="right")
+        table.add_column("Adoption", justify="right")
+        table.add_column("Quality", justify="right")
+        for snapshot in history:
+            table.add_row(
+                str(snapshot.tick),
+                f"€{snapshot.cash:,.0f}",
+                f"€{snapshot.revenue:,.0f}",
+                f"{snapshot.adoption:,d}",
+                f"{snapshot.avg_quality:.2f}",
+            )
+        return table
+
+    def render(self) -> Table:
+        if self._dashboard is None:
+            return self._rows_for(())
+        return self._rows_for(self._dashboard.tail(self._rows))
+

--- a/app/tests/__snapshots__/dashboard_kpis.txt
+++ b/app/tests/__snapshots__/dashboard_kpis.txt
@@ -1,0 +1,7 @@
+        Tick 10         
+Cash            €239,121
+Daily revenue    €46,169
+Burn rate             €0
+Reputation          60.1
+Total adoption     1,481
+Average quality     0.75

--- a/app/tests/test_ui_smoke.py
+++ b/app/tests/test_ui_smoke.py
@@ -1,0 +1,40 @@
+"""Snapshot-based smoke tests for the Textual UI."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+APP_SRC = ROOT / "app" / "src"
+SIM_SRC = ROOT / "sim" / "src"
+for path in (str(SIM_SRC), str(APP_SRC)):
+    if path not in sys.path:
+        sys.path.insert(0, path)
+
+import asyncio
+
+from rich.console import Console
+
+from ki_dev_tycoon.ui.presenter import SimulationPresenter, SimulationPresenterConfig
+from ki_dev_tycoon.ui.widgets import KpiPanel
+
+
+SNAPSHOT_DIR = Path(__file__).parent / "__snapshots__"
+
+
+def test_dashboard_kpi_snapshot() -> None:
+    """Render the KPI panel and compare it against the stored snapshot."""
+
+    presenter = SimulationPresenter(SimulationPresenterConfig(ticks=10, seed=7))
+    state = asyncio.run(presenter.build_ui_state())
+    panel = KpiPanel()
+    panel.update_view(state.dashboard)
+    console = Console(record=True, width=72)
+    console.print(panel.render())
+    output = console.export_text()
+
+    snapshot_path = SNAPSHOT_DIR / "dashboard_kpis.txt"
+    expected = snapshot_path.read_text(encoding="utf-8")
+    assert output == expected
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,16 @@
+[tool.poetry]
+name = "ki-dev-tycoon-monorepo"
+version = "0.1.0"
+description = "Workspace configuration for the KI Dev Tycoon simulation and UI packages."
+authors = ["KI Dev Tycoon Team <dev@ki-dev-tycoon.example>"]
+package-mode = false
+
+[tool.poetry.dependencies]
+python = "^3.11"
+
+[tool.poetry.workspace]
+members = ["sim", "app"]
+
+[build-system]
+requires = ["poetry-core>=1.8.0"]
+build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
## Summary
- configure a root poetry workspace and add a dedicated app/pyproject with Textual UI dependencies
- implement the Textual-based TycoonApp with navigation screens, presenter/view-model layer, and theme dialog plus CLI entry points
- document the UI flows, add snapshot coverage, and seed initial KPI panel snapshot data

## Testing
- pytest app/tests -q

------
https://chatgpt.com/codex/tasks/task_e_68e53fe565a88327b44656d80a5c6562