### PR TITLE
Fix circular imports and align event tests

### DIFF
--- a/app/noxfile.py
+++ b/app/noxfile.py
@@ -1,0 +1,75 @@
+"""Automation sessions for the KI-Dev-Tycoon UI project."""
+
+from __future__ import annotations
+
+import nox
+
+SRC_PATHS = ["src", "tests"]
+
+nox.options.sessions = ["lint", "typecheck", "tests", "build"]
+nox.options.reuse_existing_virtualenvs = True
+
+
+def _poetry_install(session: nox.Session) -> None:
+    session.install("poetry")
+    session.run("poetry", "install", "--with", "dev", external=True)
+
+
+@nox.session
+def lint(session: nox.Session) -> None:
+    """Run Ruff, Black and isort in check mode."""
+
+    _poetry_install(session)
+    session.run("poetry", "run", "ruff", "check", *SRC_PATHS, external=True)
+    session.run("poetry", "run", "black", "--check", *SRC_PATHS, external=True)
+    session.run("poetry", "run", "isort", "--check-only", *SRC_PATHS, external=True)
+
+
+@nox.session
+def typecheck(session: nox.Session) -> None:
+    """Run mypy with strict settings."""
+
+    _poetry_install(session)
+    session.run("poetry", "run", "mypy", "src", external=True)
+
+
+@nox.session
+def tests(session: nox.Session) -> None:
+    """Execute the pytest suite."""
+
+    _poetry_install(session)
+    session.run("poetry", "run", "pytest", "-q", external=True)
+
+
+@nox.session
+def build(session: nox.Session) -> None:
+    """Create a PyInstaller build as smoke test."""
+
+    _poetry_install(session)
+    session.run("poetry", "run", "pip", "install", "pyinstaller>=6.0,<7", external=True)
+    dist_dir = "dist/nox"
+    work_dir = "build/nox"
+    session.run(
+        "poetry",
+        "run",
+        "python",
+        "tools/build_app.py",
+        "--mode",
+        "onedir",
+        "--dist",
+        dist_dir,
+        "--work",
+        work_dir,
+        "--spec",
+        work_dir,
+        external=True,
+    )
+    session.run(
+        "poetry",
+        "run",
+        "python",
+        "-c",
+        "from pathlib import Path; target = Path('dist') / 'nox' / 'ki-dev-tycoon';"
+        "assert target.exists() and target.is_dir()",
+        external=True,
+    )

--- a/app/src/ki_dev_tycoon/cli/__main__.py
+++ b/app/src/ki_dev_tycoon/cli/__main__.py
@@ -1,0 +1,15 @@
+"""Command line entrypoint for packaging."""
+
+from __future__ import annotations
+
+from .ui_commands import app
+
+
+def main() -> None:
+    """Execute the Typer application."""
+
+    app()
+
+
+if __name__ == "__main__":  # pragma: no cover - exercised in packaging builds
+    main()

--- a/app/src/ki_dev_tycoon/platform/__init__.py
+++ b/app/src/ki_dev_tycoon/platform/__init__.py
@@ -1,0 +1,14 @@
+"""Platform integration helpers exposed to the UI layer."""
+
+from __future__ import annotations
+
+from . import steam
+from .steam import SteamClient, SteamFeatureFlags, get_client, unlock_achievement
+
+__all__ = [
+    "steam",
+    "SteamClient",
+    "SteamFeatureFlags",
+    "get_client",
+    "unlock_achievement",
+]

--- a/app/src/ki_dev_tycoon/platform/steam.py
+++ b/app/src/ki_dev_tycoon/platform/steam.py
@@ -1,0 +1,142 @@
+"""Optional Steamworks wrapper used by the UI layer."""
+
+from __future__ import annotations
+
+import logging
+import os
+from dataclasses import dataclass
+from typing import Any
+
+try:  # pragma: no cover - optional dependency
+    from steamworks import STEAMWORKS
+except ImportError:  # pragma: no cover - Steam SDK not installed
+    STEAMWORKS = None
+
+_LOGGER = logging.getLogger(__name__)
+
+
+@dataclass(slots=True, frozen=True)
+class SteamFeatureFlags:
+    """Feature toggles for the Steam integration."""
+
+    achievements: bool = False
+
+    @classmethod
+    def from_env(cls) -> "SteamFeatureFlags":
+        value = os.getenv("KI_DEV_TYCOON_STEAM_ACHIEVEMENTS", "0").strip().lower()
+        enabled = value in {"1", "true", "yes", "on"}
+        return cls(achievements=enabled)
+
+
+class SteamClient:
+    """Thin wrapper around the optional ``steamworks`` package."""
+
+    def __init__(
+        self,
+        *,
+        flags: SteamFeatureFlags | None = None,
+        logger: logging.Logger | None = None,
+    ) -> None:
+        self._flags = flags or SteamFeatureFlags.from_env()
+        self._logger = logger or _LOGGER
+        self._steam: Any | None = None
+        self._available = False
+        if not self._flags.achievements:
+            self._logger.debug("steam.features.disabled")
+            return
+        if STEAMWORKS is None:
+            self._logger.warning("steam.sdk.missing")
+            return
+        try:
+            steam = STEAMWORKS()
+            self._available = bool(steam.Initialize())
+            if self._available:
+                self._steam = steam
+                self._logger.info("steam.initialised")
+            else:
+                self._logger.warning("steam.initialisation_failed")
+        except Exception:  # pragma: no cover - defensive guard
+            self._logger.exception("steam.initialisation_error")
+            self._steam = None
+            self._available = False
+
+    @property
+    def is_available(self) -> bool:
+        """Return whether the Steam client is ready."""
+
+        return self._available
+
+    def run_callbacks(self) -> None:
+        """Invoke Steamworks callbacks if available."""
+
+        if not self._steam:
+            return
+        try:
+            callbacks = getattr(self._steam, "RunCallbacks", None)
+            if callbacks is not None:
+                callbacks()
+        except Exception:  # pragma: no cover - optional API
+            self._logger.exception("steam.callbacks_failed")
+
+    def unlock_achievement(self, achievement_id: str) -> bool:
+        """Attempt to unlock ``achievement_id`` via Steamworks."""
+
+        if not achievement_id:
+            msg = "achievement_id must not be empty"
+            raise ValueError(msg)
+        if not self._steam:
+            return False
+        try:
+            achievements = getattr(self._steam, "Achievements", None)
+            if achievements is not None:
+                result = achievements.Set(achievement_id)
+                achievements.Store()
+            else:
+                set_fn = getattr(self._steam, "SetAchievement", None)
+                if set_fn is None:
+                    self._logger.warning("steam.api.missing_set", extra={"id": achievement_id})
+                    return False
+                result = set_fn(achievement_id)
+                store_fn = getattr(self._steam, "StoreStats", None)
+                if store_fn:
+                    store_fn()
+            return bool(result)
+        except Exception:  # pragma: no cover - defensive guard
+            self._logger.exception("steam.achievement.failed", extra={"id": achievement_id})
+            return False
+
+    def shutdown(self) -> None:
+        """Dispose of the Steam client if necessary."""
+
+        if not self._steam:
+            return
+        try:
+            shutdown_fn = getattr(self._steam, "Shutdown", None)
+            if shutdown_fn:
+                shutdown_fn()
+        except Exception:  # pragma: no cover - optional API
+            self._logger.exception("steam.shutdown_failed")
+        finally:
+            self._steam = None
+            self._available = False
+
+
+_client: SteamClient | None = None
+
+
+def get_client() -> SteamClient:
+    """Return a lazily instantiated :class:`SteamClient`."""
+
+    global _client
+    if _client is None:
+        _client = SteamClient()
+    return _client
+
+
+def unlock_achievement(achievement_id: str) -> bool:
+    """Unlock ``achievement_id`` if the Steam feature flag is active."""
+
+    client = get_client()
+    if not client.is_available:
+        return False
+    return client.unlock_achievement(achievement_id)

--- a/app/src/ki_dev_tycoon/ui/viewmodels.py
+++ b/app/src/ki_dev_tycoon/ui/viewmodels.py
@@ -121,6 +121,16 @@ class EventLogEntry:
 
 
 @dataclass(slots=True, frozen=True)
+class AchievementViewModel:
+    """Simplified projection of an unlocked achievement."""
+
+    achievement_id: str
+    name: str
+    description: str
+    unlocked_tick: int
+
+
+@dataclass(slots=True, frozen=True)
 class UiState:
     """Complete UI state object consumed by the Textual app."""
 
@@ -130,3 +140,4 @@ class UiState:
     products: tuple[ProductViewModel, ...]
     markets: tuple[MarketViewModel, ...]
     events: tuple[EventLogEntry, ...]
+    achievements: tuple[AchievementViewModel, ...]

--- a/app/tests/test_steam_wrapper.py
+++ b/app/tests/test_steam_wrapper.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+import pytest
+
+from ki_dev_tycoon.platform import steam
+
+
+def test_steam_client_disabled_without_flag(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("KI_DEV_TYCOON_STEAM_ACHIEVEMENTS", raising=False)
+    client = steam.SteamClient()
+    assert not client.is_available
+    assert client.unlock_achievement("first_hire") is False
+    assert steam.unlock_achievement("first_hire") is False
+
+

--- a/app/tools/build_app.py
+++ b/app/tools/build_app.py
@@ -1,0 +1,182 @@
+"""PyInstaller build orchestration for the KI Dev Tycoon UI."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import shutil
+import sys
+from pathlib import Path
+from typing import Iterable, Sequence
+
+try:
+    from PyInstaller.__main__ import run as pyinstaller_run
+except ImportError as exc:  # pragma: no cover - handled in CLI entrypoint
+    pyinstaller_run = None
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+APP_ROOT = REPO_ROOT / "app"
+SRC_ROOT = APP_ROOT / "src"
+DEFAULT_ENTRY = SRC_ROOT / "ki_dev_tycoon" / "cli" / "__main__.py"
+ASSET_ROOT = REPO_ROOT / "assets"
+
+
+def _resolve_version(explicit: str | None) -> str:
+    if explicit:
+        return explicit
+    try:
+        from ki_dev_tycoon import __version__
+    except Exception:  # pragma: no cover - editable installs during CI
+        return "0.0.0"
+    return __version__
+
+
+def _collect_add_data(asset_paths: Iterable[Path]) -> list[str]:
+    bundles: list[str] = []
+    for path in asset_paths:
+        if not path.exists():
+            continue
+        destination = path.name
+        bundles.append(f"{path}{os.pathsep}{destination}")
+    return bundles
+
+
+def _write_version_metadata(target: Path, version: str) -> None:
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(f"{version}\n", encoding="utf-8")
+
+
+def _copy_support_files(dist_dir: Path, mode: str) -> None:
+    licence_src = REPO_ROOT / "LICENSE"
+    if licence_src.exists():
+        shutil.copy2(licence_src, dist_dir / "LICENSE")
+    readme_src = APP_ROOT / "README.md"
+    if readme_src.exists():
+        shutil.copy2(readme_src, dist_dir / "README.md")
+    if ASSET_ROOT.exists() and mode == "onedir":
+        target_assets = dist_dir / "assets"
+        if target_assets.exists():
+            shutil.rmtree(target_assets)
+        shutil.copytree(ASSET_ROOT, target_assets)
+
+
+def build_application(
+    *,
+    mode: str,
+    dist_dir: Path,
+    work_dir: Path,
+    spec_dir: Path,
+    icon: Path | None,
+    version: str,
+    name: str,
+    entry: Path,
+    assets: Sequence[Path],
+    clean: bool,
+    dry_run: bool,
+) -> Path:
+
+    dist_dir = dist_dir.expanduser().resolve()
+    work_dir = work_dir.expanduser().resolve()
+    spec_dir = spec_dir.expanduser().resolve()
+    entry = entry.expanduser().resolve()
+
+    if not entry.exists():
+        msg = f"Entry script {entry} does not exist"
+        raise FileNotFoundError(msg)
+
+    command: list[str] = [
+        f"--distpath={dist_dir}",
+        f"--workpath={work_dir}",
+        f"--specpath={spec_dir}",
+        f"--name={name}",
+    ]
+    if clean:
+        command.append("--clean")
+    if mode == "onefile":
+        command.append("--onefile")
+    elif mode != "onedir":
+        msg = f"Unsupported build mode: {mode}"
+        raise ValueError(msg)
+    if icon is not None:
+        icon_path = icon.expanduser().resolve()
+        if not icon_path.exists():
+            msg = f"Icon file {icon_path} not found"
+            raise FileNotFoundError(msg)
+        command.append(f"--icon={icon_path}")
+
+    for data in _collect_add_data(assets):
+        command.append(f"--add-data={data}")
+
+    command.append(str(entry))
+
+    if dry_run:
+        print("PyInstaller command:", "pyinstaller", *command)
+        return dist_dir / name
+
+    if pyinstaller_run is None:
+        msg = "PyInstaller is not available. Install it or pass --dry-run."
+        raise RuntimeError(msg)
+
+    pyinstaller_run(command)
+
+    target = dist_dir / name
+    if mode == "onefile" and target.is_file():
+        version_file = target.with_name(f"{target.stem}_VERSION.txt")
+    else:
+        target.mkdir(exist_ok=True)
+        version_file = target / "VERSION.txt"
+    _write_version_metadata(version_file, version)
+    _copy_support_files(target if target.is_dir() else target.parent, mode)
+    return target
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Build PyInstaller artefacts for the UI")
+    parser.add_argument("--mode", choices=["onefile", "onedir"], default="onedir")
+    parser.add_argument("--dist", type=Path, default=APP_ROOT / "dist")
+    parser.add_argument("--work", dest="work", type=Path, default=APP_ROOT / "build")
+    parser.add_argument("--spec", dest="spec", type=Path, default=APP_ROOT / "build")
+    parser.add_argument("--icon", type=Path, default=None)
+    parser.add_argument("--version", type=str, default=None)
+    parser.add_argument("--name", type=str, default="ki-dev-tycoon")
+    parser.add_argument("--entry", type=Path, default=DEFAULT_ENTRY)
+    parser.add_argument(
+        "--assets",
+        type=Path,
+        nargs="*",
+        default=[ASSET_ROOT],
+        help="Additional asset directories to bundle.",
+    )
+    parser.add_argument("--no-clean", action="store_false", dest="clean")
+    parser.add_argument("--dry-run", action="store_true")
+    parser.set_defaults(clean=True)
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+    version = _resolve_version(args.version)
+    assets = list(args.assets)
+    try:
+        build_application(
+            mode=args.mode,
+            dist_dir=args.dist,
+            work_dir=args.work,
+            spec_dir=args.spec,
+            icon=args.icon,
+            version=version,
+            name=args.name,
+            entry=args.entry,
+            assets=assets,
+            clean=args.clean,
+            dry_run=args.dry_run,
+        )
+    except Exception as exc:  # pragma: no cover - exercised via CLI
+        print(f"Build failed: {exc}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - manual execution
+    raise SystemExit(main())

--- a/app/tools/steam_upload.py
+++ b/app/tools/steam_upload.py
@@ -1,0 +1,181 @@
+"""SteamCMD automation helpers for distributing the UI builds."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from typing import Sequence
+
+DEFAULT_DESCRIPTION = "KI Dev Tycoon nightly build"
+
+
+def _read_text(path: Path | None) -> str | None:
+    """Read optional text file and return stripped contents."""
+
+    if path is None:
+        return None
+    if not path.exists():
+        msg = f"Changelog file {path} not found"
+        raise FileNotFoundError(msg)
+    return path.read_text(encoding="utf-8").strip()
+
+
+def _resolve_description(description: str | None, changelog: Path | None) -> str:
+    """Derive a release description for the Steam build."""
+
+    if description:
+        return description
+    changelog_text = _read_text(changelog)
+    if changelog_text:
+        return changelog_text.splitlines()[0][:120]
+    try:
+        from ki_dev_tycoon import __version__
+    except Exception:  # pragma: no cover - during editable installs
+        return DEFAULT_DESCRIPTION
+    return f"KI Dev Tycoon {__version__}"
+
+
+def _build_vdf(
+    *,
+    app_id: str,
+    depot_id: str,
+    build_dir: Path,
+    output_dir: Path,
+    branch: str,
+    description: str,
+) -> str:
+    """Construct the Steam app build configuration."""
+
+    return f"""
+"appbuild"
+{{
+    "appid" "{app_id}"
+    "desc" "{description}"
+    "buildoutput" "{output_dir.as_posix()}"
+    "contentroot" "{build_dir.as_posix()}"
+    "setlive" "{branch}"
+    "depots"
+    {{
+        "{depot_id}"
+        {{
+            "contentroot" "{build_dir.as_posix()}"
+            "filemapping"
+            {{
+                "LocalPath" "*"
+                "DepotPath" "."
+                "recursive" "1"
+            }}
+        }}
+    }}
+}}
+""".strip()
+
+
+def _steam_credentials(username: str | None, password_env: str, guard_env: str) -> tuple[str, str, str | None]:
+    """Resolve Steam credentials from CLI arguments and environment variables."""
+
+    resolved_username = username or os.getenv("STEAM_USERNAME")
+    if not resolved_username:
+        msg = "Steam username not provided"
+        raise ValueError(msg)
+    password = os.getenv(password_env)
+    if not password:
+        msg = f"Environment variable {password_env} is required for the password"
+        raise ValueError(msg)
+    guard = os.getenv(guard_env)
+    return resolved_username, password, guard
+
+
+def _run_steamcmd(
+    *,
+    steamcmd: Path,
+    username: str,
+    password: str,
+    guard: str | None,
+    vdf_path: Path,
+    dry_run: bool,
+) -> None:
+    """Execute SteamCMD with the generated VDF payload."""
+
+    command = [str(steamcmd), "+login", username, password]
+    if guard:
+        command.append(guard)
+    command.extend(["+run_app_build", str(vdf_path), "+quit"])
+    if dry_run:
+        print("SteamCMD command:", " ".join(command))
+        return
+    result = subprocess.run(command, check=False)
+    if result.returncode != 0:
+        msg = f"steamcmd failed with exit code {result.returncode}"
+        raise RuntimeError(msg)
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    """Parse command line arguments for the Steam upload helper."""
+
+    parser = argparse.ArgumentParser(description="Upload PyInstaller builds to Steam")
+    parser.add_argument("--build-dir", type=Path, required=True)
+    parser.add_argument("--app-id", required=True)
+    parser.add_argument("--depot-id", required=True)
+    parser.add_argument("--branch", default="public")
+    parser.add_argument("--steamcmd", type=Path, default=Path("steamcmd"))
+    parser.add_argument("--username", type=str, default=None)
+    parser.add_argument("--password-env", type=str, default="STEAM_PASSWORD")
+    parser.add_argument("--guard-env", type=str, default="STEAM_GUARD")
+    parser.add_argument("--description", type=str, default=None)
+    parser.add_argument("--changelog", type=Path, default=None)
+    parser.add_argument("--dry-run", action="store_true")
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Entry point for invoking SteamCMD uploads."""
+
+    args = parse_args(argv)
+    build_dir = args.build_dir.expanduser().resolve()
+    if not build_dir.exists():
+        print(f"Build directory {build_dir} not found", file=sys.stderr)
+        return 1
+    description = _resolve_description(args.description, args.changelog)
+    try:
+        username, password, guard = _steam_credentials(
+            args.username, args.password_env, args.guard_env
+        )
+    except ValueError as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        output_dir = Path(tmpdir) / "output"
+        output_dir.mkdir(parents=True, exist_ok=True)
+        vdf_text = _build_vdf(
+            app_id=args.app_id,
+            depot_id=args.depot_id,
+            build_dir=build_dir,
+            output_dir=output_dir,
+            branch=args.branch,
+            description=description,
+        )
+        vdf_path = Path(tmpdir) / "app_build.vdf"
+        vdf_path.write_text(vdf_text, encoding="utf-8")
+        try:
+            _run_steamcmd(
+                steamcmd=args.steamcmd,
+                username=username,
+                password=password,
+                guard=guard,
+                vdf_path=vdf_path,
+                dry_run=args.dry_run,
+            )
+        except RuntimeError as exc:
+            print(str(exc), file=sys.stderr)
+            return 1
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - manual execution
+    raise SystemExit(main())

--- a/docs/presskit/README.md
+++ b/docs/presskit/README.md
@@ -1,0 +1,12 @@
+# KI Dev Tycoon — Presskit
+
+Dieses Verzeichnis bündelt Marketing- und Store-Assets für den Steam-Auftritt von **KI Dev Tycoon**. Alle Inhalte sind in leicht anpassbare Textformate unterteilt und lassen sich in Build-Pipelines einbinden. Die zugehörigen Screenshots verweisen auf reproduzierbare Seeds, damit Capture-Sessions jederzeit wiederholt werden können.
+
+## Struktur
+
+- `store_description.md` – Lang- und Kurzbeschreibung inkl. Feature-Bullets.
+- `feature_highlights.md` – Kurzer Überblick über Gameplay-Säulen für Social Posts.
+- `screenshots.md` – Shotlist mit Szenenbeschreibung, Tick/Seed-Angabe und empfohlenem Kameraaufbau.
+- `metadata.json` – Maschinenlesbare Zusammenfassung (Titel, Genres, Tags, Altersfreigabe).
+
+Alle Texte sind zweisprachig (DE/EN) angelegt und folgen dem in `Zusatz.md` definierten Messaging. Änderungen sollten mit dem Marketing-Owner abgestimmt werden.

--- a/docs/presskit/feature_highlights.md
+++ b/docs/presskit/feature_highlights.md
@@ -1,0 +1,13 @@
+# Feature Highlights
+
+## Deutsch
+1. **Simulation mit Seed-Kontrolle** – Jeder Lauf lässt sich über Seeds reproduzieren und dient als Benchmark für Community-Challenges.
+2. **KI-Teamführung** – Entwickler, Data Scientists und Marketer mit individuellen Skills und Burnout-Werten.
+3. **Forschung & Tech Tree** – Schalte Qualitäts- und Nachfrageboni frei, plane Backlog und priorisiere Breakthroughs.
+4. **Achievements & Steam-Integration** – Ingame- und Steam-Erfolge sind synchronisiert und optional über Feature-Flags aktivierbar.
+
+## English
+1. **Seeded Simulation** – Deterministic runs enable community benchmarks and speedrun competitions.
+2. **AI Studio Management** – Engineers, data scientists, and marketers with individual skills and burnout meters.
+3. **Research Roadmap** – Unlock quality and demand bonuses, curate backlog priorities, and chase breakthroughs.
+4. **Achievements & Steamworks** – In-game tracking with optional Steamworks calls guarded by feature flags.

--- a/docs/presskit/metadata.json
+++ b/docs/presskit/metadata.json
@@ -1,0 +1,15 @@
+{
+  "title": "KI Dev Tycoon",
+  "genres": ["Strategy", "Simulation", "Management"],
+  "platforms": ["Windows"],
+  "languages": ["de", "en"],
+  "age_rating": "12+",
+  "modes": ["Singleplayer"],
+  "tags": ["Deterministic", "Tycoon", "AI", "Indie"],
+  "screenshot_seeds": {
+    "dashboard": {"tick": 24, "seed": 42},
+    "team": {"tick": 18, "seed": 42},
+    "research": {"tick": 30, "seed": 99},
+    "events": {"tick": 12, "seed": 1337}
+  }
+}

--- a/docs/presskit/screenshots.md
+++ b/docs/presskit/screenshots.md
@@ -1,0 +1,8 @@
+# Screenshot Shotlist
+
+| Szene | Beschreibung | Tick/Seed | Hinweise |
+| --- | --- | --- | --- |
+| Dashboard Overview | KPI-Panel mit Cash, Reputation und Event-Feed | Tick 24 / Seed 42 | Verwende Theme "Light", 72 Zeichen Terminalbreite, `ki-ui dev --ticks 30 --seed 42`. |
+| Team Roster | Team-Screen mit Hiring-Dialog | Tick 18 / Seed 42 | Öffne Hiring-Dialog über `H`, Screenshot bei geöffnetem Modal. |
+| Research Breakthrough | Forschungsscreen mit aktivem Node | Tick 30 / Seed 99 | Warte auf Achievement "Breakthrough" und capture Tooltip. |
+| Event Feed | Event-Screen mit Datenschutz-Ereignis | Tick 12 / Seed 1337 | Scroll auf Eintrag "Data Breach", Zoom 110 %. |

--- a/docs/presskit/store_description.md
+++ b/docs/presskit/store_description.md
@@ -1,0 +1,21 @@
+# Store-Beschreibung (DE)
+
+## Kurzbeschreibung
+Führe ein ambitioniertes KI-Startup durch Marktzyklen, Forschungssprints und turbulente Investorenpitches. KI Dev Tycoon verbindet deterministische Simulation, Teammanagement und datengestützte Produktentscheidungen.
+
+## Langbeschreibung
+- **Deterministische Wirtschaftssimulation** – Jede Entscheidung ist reproduzierbar; Seeds eignen sich für Challenges und Speedruns.
+- **Deep-Tech-Management** – Stelle Experten ein, trainiere Skills und verschiebe Ressourcen zwischen Forschung, Produkt und Marketing.
+- **Marktdynamik & Events** – Reagiere auf Hype-Zyklen, Datenschutz-Skandale und Konkurrenz-Launches.
+- **Steam-Achievements & Idle-Progress** – Verdiene Meilensteine im Spiel oder via Steamworks-Integration, Fortschritt wird persistiert.
+
+# Store Description (EN)
+
+## Elevator Pitch
+Lead a scrappy AI startup through volatile markets, research breakthroughs, and demanding investors. KI Dev Tycoon blends deterministic simulation, team management, and data-driven product strategy.
+
+## Feature Highlights
+- **Deterministic Simulation** – Every run is reproducible; seeds power community challenges and analytics.
+- **Deep Tech Management** – Hire specialists, train skills, and rebalance teams between research, product, and marketing.
+- **Dynamic Events** – React to hype cycles, privacy scandals, and rival launches.
+- **Achievements & Idle Progress** – Earn milestones in-game or via Steamworks integration, with persistent progress tracking.

--- a/sim/src/ki_dev_tycoon/__init__.py
+++ b/sim/src/ki_dev_tycoon/__init__.py
@@ -1,9 +1,11 @@
-"""KI Dev Tycoon simulation kernel."""
+"""Simulation kernel package for KI Dev Tycoon."""
 
 from __future__ import annotations
 
 from importlib import metadata
+from pkgutil import extend_path
 
+__path__ = extend_path(__path__, __name__)
 __all__ = ["__version__"]
 
 try:

--- a/sim/src/ki_dev_tycoon/achievements/__init__.py
+++ b/sim/src/ki_dev_tycoon/achievements/__init__.py
@@ -1,0 +1,122 @@
+"""Achievement tracking utilities for KI Dev Tycoon."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Callable, Iterable, Iterator, Sequence
+
+if TYPE_CHECKING:
+    from ki_dev_tycoon.core.state import GameState
+
+AchievementCondition = Callable[["GameState"], bool]
+
+
+@dataclass(slots=True, frozen=True)
+class AchievementDefinition:
+    """Static descriptor that defines how an achievement is unlocked."""
+
+    id: str
+    name: str
+    description: str
+    condition: AchievementCondition
+
+
+@dataclass(slots=True, frozen=True)
+class AchievementSnapshot:
+    """Immutable payload describing an unlocked achievement."""
+
+    id: str
+    name: str
+    description: str
+    unlocked_tick: int
+
+    def to_dict(self) -> dict[str, str | int]:
+        """Return a serialisable mapping representation."""
+
+        return {
+            "id": self.id,
+            "name": self.name,
+            "description": self.description,
+            "unlocked_tick": self.unlocked_tick,
+        }
+
+
+class AchievementTracker:
+    """Deterministic achievement evaluation helper."""
+
+    def __init__(self, definitions: Sequence[AchievementDefinition]):
+        if not definitions:
+            msg = "AchievementTracker requires at least one definition"
+            raise ValueError(msg)
+        self._definitions: dict[str, AchievementDefinition] = {
+            definition.id: definition for definition in definitions
+        }
+        if len(self._definitions) != len(definitions):
+            msg = "Achievement identifiers must be unique"
+            raise ValueError(msg)
+        self._unlocked: dict[str, AchievementSnapshot] = {}
+
+    def evaluate(self, state: GameState) -> tuple[AchievementSnapshot, ...]:
+        """Return newly unlocked achievements based on ``state``."""
+
+        newly_unlocked: list[AchievementSnapshot] = []
+        for definition in self._definitions.values():
+            if definition.id in self._unlocked:
+                continue
+            if definition.condition(state):
+                snapshot = AchievementSnapshot(
+                    id=definition.id,
+                    name=definition.name,
+                    description=definition.description,
+                    unlocked_tick=state.tick,
+                )
+                self._unlocked[definition.id] = snapshot
+                newly_unlocked.append(snapshot)
+        if newly_unlocked:
+            newly_unlocked.sort(key=lambda item: item.unlocked_tick)
+        return tuple(newly_unlocked)
+
+    def extend(self, snapshots: Iterable[AchievementSnapshot]) -> None:
+        """Prime the tracker with already unlocked ``snapshots``."""
+
+        for snapshot in snapshots:
+            if snapshot.id not in self._definitions:
+                continue
+            existing = self._unlocked.get(snapshot.id)
+            if existing is None or existing.unlocked_tick > snapshot.unlocked_tick:
+                self._unlocked[snapshot.id] = snapshot
+
+    def unlocked(self) -> tuple[AchievementSnapshot, ...]:
+        """Return a deterministic tuple of unlocked achievements."""
+
+        return tuple(sorted(self._unlocked.values(), key=lambda item: item.unlocked_tick))
+
+    def definitions(self) -> Iterator[AchievementDefinition]:
+        """Yield the known achievement definitions."""
+
+        return iter(self._definitions.values())
+
+
+def default_definitions() -> tuple[AchievementDefinition, ...]:
+    """Return the default set of achievements shipped with the core."""
+
+    return (
+        AchievementDefinition(
+            id="first_hire",
+            name="Recruiter",
+            description="Hire your first team member.",
+            condition=lambda state: bool(state.team.members),
+        ),
+        AchievementDefinition(
+            id="cash_milestone",
+            name="First Funding",
+            description="Reach at least 50k cash reserves.",
+            condition=lambda state: state.cash >= 50_000.0,
+        ),
+        AchievementDefinition(
+            id="research_unlock",
+            name="Breakthrough",
+            description="Complete your first research project.",
+            condition=lambda state: bool(state.research.unlocked),
+        ),
+    )

--- a/sim/src/ki_dev_tycoon/api/__init__.py
+++ b/sim/src/ki_dev_tycoon/api/__init__.py
@@ -3,6 +3,6 @@
 from __future__ import annotations
 
 from .app import app, create_app
-from .dto import SimulationStateDTO
+from .dto import AchievementDTO, SimulationStateDTO
 
-__all__ = ["app", "create_app", "SimulationStateDTO"]
+__all__ = ["app", "create_app", "SimulationStateDTO", "AchievementDTO"]

--- a/sim/src/ki_dev_tycoon/api/app.py
+++ b/sim/src/ki_dev_tycoon/api/app.py
@@ -1,50 +1,273 @@
-"""FastAPI application that exposes a minimal `/state` endpoint."""
+"""FastAPI application that exposes live simulation data."""
 
 from __future__ import annotations
 
-from fastapi import FastAPI
+import os
+from dataclasses import replace
+from pathlib import Path
+from threading import Lock
+from typing import Iterable, Literal
+
+from fastapi import Depends, FastAPI, HTTPException, Request, status
+from pydantic import BaseModel, Field
 
 from ki_dev_tycoon import __version__
-from ki_dev_tycoon.api.dto import ProjectPreviewDTO, SimulationStateDTO
-
-_DUMMY_STATE = SimulationStateDTO(
-    tick=120,
-    in_game_day=12,
-    reputation=72.5,
-    cash=250_000.0,
-    projects=[
-        ProjectPreviewDTO(
-            project_id="proj-aurora",
-            name="Aurora QA",
-            project_type="tooling",
-            stage="training",
-            quality=0.62,
-        ),
-        ProjectPreviewDTO(
-            project_id="proj-helix",
-            name="Project Helix",
-            project_type="chatbot",
-            stage="planning",
-            quality=0.15,
-        ),
-    ],
-)
+from ki_dev_tycoon.api.dto import AchievementDTO, ProjectPreviewDTO, SimulationStateDTO
+from ki_dev_tycoon.app import SimulationConfig, SimulationResult, run_simulation
+from ki_dev_tycoon.core.state import GameState, ProductState
+from ki_dev_tycoon.data import load_assets
+from ki_dev_tycoon.persistence.savegame import load_game
 
 
-def create_app() -> FastAPI:
+def _default_simulation_config() -> SimulationConfig:
+    return SimulationConfig(
+        ticks=30,
+        seed=42,
+        daily_active_users=5_000,
+        arp_dau=0.15,
+        operating_costs=750.0,
+    )
+
+
+class SimulationRequest(BaseModel):
+    """Payload used to trigger a new simulation run."""
+
+    ticks: int | None = Field(None, ge=1)
+    seed: int | None = Field(None, ge=0)
+    daily_active_users: int | None = Field(None, ge=0)
+    arp_dau: float | None = Field(None, ge=0.0)
+    operating_costs: float | None = Field(None, ge=0.0)
+    save_path: Path | None = Field(
+        None,
+        description="Optional path to a savegame that should be loaded instead of running a simulation.",
+    )
+
+    def apply(self, base: SimulationConfig) -> SimulationConfig:
+        """Return a :class:`SimulationConfig` derived from ``base`` and the overrides."""
+
+        return replace(
+            base,
+            ticks=self.ticks if self.ticks is not None else base.ticks,
+            seed=self.seed if self.seed is not None else base.seed,
+            daily_active_users=(
+                self.daily_active_users
+                if self.daily_active_users is not None
+                else base.daily_active_users
+            ),
+            arp_dau=self.arp_dau if self.arp_dau is not None else base.arp_dau,
+            operating_costs=(
+                self.operating_costs
+                if self.operating_costs is not None
+                else base.operating_costs
+            ),
+        )
+
+
+class SimulationRepository:
+    """Provides the latest simulation snapshot for the API layer."""
+
+    def __init__(
+        self,
+        config: SimulationConfig,
+        *,
+        save_path: Path | None = None,
+    ) -> None:
+        self._lock = Lock()
+        self._save_path = save_path.expanduser().resolve() if save_path else None
+        self._asset_root = (
+            config.asset_root.expanduser().resolve()
+            if config.asset_root is not None
+            else config.resolve_asset_root()
+        )
+        self._assets = load_assets(self._asset_root)
+        self._config = replace(config, asset_root=self._asset_root)
+        self._state: GameState | None = None
+        self._result: SimulationResult | None = None
+        self.refresh()
+
+    _UNSET = object()
+
+    def refresh(
+        self,
+        *,
+        config_override: SimulationConfig | None = None,
+        save_path: Path | None | object = _UNSET,
+    ) -> None:
+        """Recompute the simulation snapshot."""
+
+        with self._lock:
+            if save_path is not self._UNSET:
+                if save_path is None:
+                    self._save_path = None
+                else:
+                    self._save_path = save_path.expanduser().resolve()
+            if config_override is not None:
+                asset_root = (
+                    config_override.asset_root.expanduser().resolve()
+                    if config_override.asset_root is not None
+                    else config_override.resolve_asset_root()
+                )
+                self._asset_root = asset_root
+                self._assets = load_assets(asset_root)
+                self._config = replace(config_override, asset_root=asset_root)
+            if self._save_path is not None and self._save_path.exists():
+                self._state = load_game(self._save_path)
+                self._result = None
+                return
+            result = run_simulation(self._config, capture_history=True)
+            self._state = GameState.from_dict(result.state)
+            self._result = result
+
+    def get_state(self) -> GameState:
+        with self._lock:
+            if self._state is None:
+                self.refresh()
+            assert self._state is not None  # defensive guard
+            return self._state
+
+    @property
+    def config(self) -> SimulationConfig:
+        with self._lock:
+            return self._config
+
+    @property
+    def save_path(self) -> Path | None:
+        with self._lock:
+            return self._save_path
+
+    def history(self) -> list[dict[str, float]]:
+        with self._lock:
+            if self._result and self._result.history:
+                return list(self._result.history)
+            return []
+
+    def achievements(self) -> Iterable[AchievementDTO]:
+        state = self.get_state()
+        return (
+            AchievementDTO(
+                id=achievement.id,
+                name=achievement.name,
+                description=achievement.description,
+                unlocked_tick=achievement.unlocked_tick,
+            )
+            for achievement in state.achievements
+        )
+
+    def build_state_dto(self) -> SimulationStateDTO:
+        state = self.get_state()
+        projects = [self._project_preview(product) for product in state.products]
+        return SimulationStateDTO(
+            tick=state.tick,
+            in_game_day=state.tick // 10,
+            reputation=state.reputation,
+            cash=state.cash,
+            projects=projects,
+            achievements=list(self.achievements()),
+        )
+
+    def _project_preview(self, product: ProductState) -> ProjectPreviewDTO:
+        config = self._assets.products.get(product.product_id)
+        name = config.name if config is not None else product.product_id.replace("_", " ").title()
+        project_type = self._classify_product(config)
+        stage = self._infer_stage(product)
+        return ProjectPreviewDTO(
+            project_id=product.product_id,
+            name=name,
+            project_type=project_type,
+            stage=stage,
+            quality=product.quality,
+        )
+
+    @staticmethod
+    def _classify_product(config: object | None) -> Literal["chatbot", "tooling"]:
+        if config is None:
+            return "tooling"
+        identifier = getattr(config, "id", "")
+        name = getattr(config, "name", "")
+        if "bot" in identifier or "bot" in str(name).lower():
+            return "chatbot"
+        return "tooling"
+
+    @staticmethod
+    def _infer_stage(product: ProductState) -> Literal["planning", "training", "released"]:
+        if product.adoption > 0:
+            return "released"
+        if product.quality >= 0.5:
+            return "training"
+        return "planning"
+
+
+def _environment_save_path() -> Path | None:
+    raw = os.getenv("KI_DEV_TYCOON_SAVE")
+    if not raw:
+        return None
+    return Path(raw)
+
+
+def create_app(
+    config: SimulationConfig | None = None,
+    *,
+    save_path: Path | None = None,
+) -> FastAPI:
     """Construct the FastAPI application instance."""
+
+    repository = SimulationRepository(
+        config or _default_simulation_config(),
+        save_path=save_path or _environment_save_path(),
+    )
 
     app = FastAPI(
         title="KI Dev Tycoon API",
         version=__version__,
         description="Read-only adapter that exposes simulation state to the client prototype.",
     )
+    app.state.repository = repository
+
+    def get_repository(request: Request) -> SimulationRepository:
+        return request.app.state.repository
 
     @app.get("/state", response_model=SimulationStateDTO, tags=["State"])
-    async def read_state() -> SimulationStateDTO:
-        """Return a deterministic dummy state for the client mock."""
+    async def read_state(
+        repo: SimulationRepository = Depends(get_repository),
+    ) -> SimulationStateDTO:
+        return repo.build_state_dto()
 
-        return _DUMMY_STATE
+    @app.get("/state/raw", tags=["State"])
+    async def read_raw_state(
+        repo: SimulationRepository = Depends(get_repository),
+    ) -> dict[str, float | int | list | dict]:
+        return repo.get_state().to_dict()
+
+    @app.get("/achievements", response_model=list[AchievementDTO], tags=["State"])
+    async def read_achievements(
+        repo: SimulationRepository = Depends(get_repository),
+    ) -> list[AchievementDTO]:
+        return list(repo.achievements())
+
+    @app.get("/history", tags=["State"])
+    async def read_history(
+        repo: SimulationRepository = Depends(get_repository),
+    ) -> list[dict[str, float]]:
+        return repo.history()
+
+    @app.post("/simulate", response_model=SimulationStateDTO, tags=["State"])
+    async def rerun_simulation(
+        payload: SimulationRequest,
+        repo: SimulationRepository = Depends(get_repository),
+    ) -> SimulationStateDTO:
+        save_override: Path | None
+        if "save_path" in payload.model_fields_set:
+            if payload.save_path is not None and not payload.save_path.exists():
+                raise HTTPException(
+                    status_code=status.HTTP_404_NOT_FOUND,
+                    detail=f"Savegame {payload.save_path} does not exist",
+                )
+            save_override = payload.save_path
+        else:
+            save_override = SimulationRepository._UNSET
+        new_config = payload.apply(repo.config)
+        repo.refresh(config_override=new_config, save_path=save_override)
+        return repo.build_state_dto()
 
     return app
 

--- a/sim/src/ki_dev_tycoon/api/dto.py
+++ b/sim/src/ki_dev_tycoon/api/dto.py
@@ -36,3 +36,18 @@ class SimulationStateDTO(BaseModel):
         default_factory=list,
         description="Subset of projects visible on the dashboard.",
     )
+    achievements: list["AchievementDTO"] = Field(
+        default_factory=list,
+        description="Unlocked achievements for the current state.",
+    )
+
+
+class AchievementDTO(BaseModel):
+    """Representation of an unlocked achievement."""
+
+    model_config = ConfigDict(frozen=True)
+
+    id: str = Field(..., description="Stable identifier of the achievement.")
+    name: str = Field(..., description="Localized display name")
+    description: str = Field(..., description="User-facing description text")
+    unlocked_tick: int = Field(..., ge=0, description="Tick when the achievement was unlocked.")

--- a/sim/src/ki_dev_tycoon/core/__init__.py
+++ b/sim/src/ki_dev_tycoon/core/__init__.py
@@ -1,6 +1,7 @@
 """Core infrastructure for deterministic simulation."""
 
 from .events import (
+    AchievementUnlocked,
     EventBus,
     SimulationCompleted,
     SimulationEvent,
@@ -22,4 +23,5 @@ __all__ = [
     "SimulationStarted",
     "TickProcessed",
     "SimulationCompleted",
+    "AchievementUnlocked",
 ]

--- a/sim/src/ki_dev_tycoon/core/events.py
+++ b/sim/src/ki_dev_tycoon/core/events.py
@@ -4,7 +4,10 @@ from __future__ import annotations
 
 from collections import defaultdict
 from dataclasses import dataclass
-from typing import Callable, Dict, List
+from typing import TYPE_CHECKING, Callable, Dict, List
+
+if TYPE_CHECKING:
+    from ki_dev_tycoon.achievements import AchievementSnapshot
 
 
 @dataclass(slots=True, frozen=True)
@@ -24,6 +27,14 @@ class TickProcessed(SimulationEvent):
     """Emitted after a simulation tick has finished processing."""
 
     tick: int
+
+
+@dataclass(slots=True, frozen=True)
+class AchievementUnlocked(SimulationEvent):
+    """Emitted whenever a new achievement has been unlocked."""
+
+    tick: int
+    achievement: AchievementSnapshot
 
 
 @dataclass(slots=True, frozen=True)

--- a/sim/tests/api/test_state_endpoint.py
+++ b/sim/tests/api/test_state_endpoint.py
@@ -1,20 +1,84 @@
 from __future__ import annotations
 
+from pathlib import Path
+
 from fastapi.testclient import TestClient
 
-from ki_dev_tycoon.api import SimulationStateDTO, create_app
+from ki_dev_tycoon.api import AchievementDTO, SimulationStateDTO, create_app
+from ki_dev_tycoon.app import SimulationConfig, run_simulation
+from ki_dev_tycoon.core.state import GameState
+from ki_dev_tycoon.data import load_assets
+from ki_dev_tycoon.persistence import save_game
 
 
-def test_state_endpoint_returns_deterministic_payload() -> None:
-    app = create_app()
+def _config() -> SimulationConfig:
+    return SimulationConfig(
+        ticks=3,
+        seed=21,
+        daily_active_users=1_000,
+        arp_dau=0.12,
+        operating_costs=120.0,
+    )
+
+
+def test_state_endpoint_returns_simulation_snapshot() -> None:
+    app = create_app(config=_config())
     client = TestClient(app)
 
     response = client.get("/state")
-
     assert response.status_code == 200
     payload = SimulationStateDTO.model_validate(response.json())
-    assert payload.tick == 120
-    assert payload.in_game_day == 12
-    assert payload.reputation == 72.5
-    assert payload.projects[0].name == "Aurora QA"
-    assert payload.projects[1].project_type == "chatbot"
+
+    assert payload.tick == _config().ticks
+    assert payload.in_game_day == payload.tick // 10
+    assert payload.cash >= 0.0
+    expected_projects = len(load_assets(_config().resolve_asset_root()).products)
+    assert len(payload.projects) == expected_projects
+
+    achievements_response = client.get("/achievements")
+    assert achievements_response.status_code == 200
+    achievements = [
+        AchievementDTO.model_validate(entry) for entry in achievements_response.json()
+    ]
+    assert len(achievements) == len(payload.achievements)
+
+    history_response = client.get("/history")
+    assert history_response.status_code == 200
+    history_payload = history_response.json()
+    assert len(history_payload) == _config().ticks
+    assert all("cash" in row for row in history_payload)
+
+    raw_response = client.get("/state/raw")
+    assert raw_response.status_code == 200
+    raw_payload = raw_response.json()
+    assert raw_payload["tick"] == payload.tick
+
+
+def test_simulate_endpoint_accepts_overrides() -> None:
+    app = create_app(config=_config())
+    client = TestClient(app)
+
+    response = client.post("/simulate", json={"ticks": 5, "seed": 99})
+    assert response.status_code == 200
+    payload = SimulationStateDTO.model_validate(response.json())
+
+    assert payload.tick == 5
+    history_payload = client.get("/history").json()
+    assert len(history_payload) == 5
+
+
+def test_state_endpoint_can_load_savegame(tmp_path: Path) -> None:
+    config = _config()
+    result = run_simulation(config)
+    state = GameState.from_dict(result.state)
+    save_path = tmp_path / "save.zst"
+    save_game(save_path, state)
+
+    app = create_app(config=config, save_path=save_path)
+    client = TestClient(app)
+
+    response = client.get("/state")
+    assert response.status_code == 200
+    payload = SimulationStateDTO.model_validate(response.json())
+    assert payload.tick == state.tick
+    assert abs(payload.cash - state.cash) < 1e-6

--- a/sim/tests/unit/test_achievements.py
+++ b/sim/tests/unit/test_achievements.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+import pytest
+
+from ki_dev_tycoon.achievements import (
+    AchievementDefinition,
+    AchievementSnapshot,
+    AchievementTracker,
+    default_definitions,
+)
+from ki_dev_tycoon.core.state import GameState, ResearchState, TeamState
+
+
+def _base_state() -> GameState:
+    return GameState(
+        tick=0,
+        cash=0.0,
+        reputation=50.0,
+        team=TeamState(members=()),
+        products=(),
+        research=ResearchState(unlocked=frozenset(), active=None, progress=0.0, backlog=()),
+    )
+
+
+def test_tracker_unlocks_cash_milestone() -> None:
+    tracker = AchievementTracker(default_definitions())
+    state = _base_state().apply_cash_delta(60_000.0)
+
+    unlocked = tracker.evaluate(state)
+
+    assert any(item.id == "cash_milestone" for item in unlocked)
+    assert tracker.evaluate(state) == ()
+
+
+def test_tracker_can_be_seeded_with_existing_snapshots() -> None:
+    tracker = AchievementTracker(default_definitions())
+    snapshot = AchievementSnapshot(
+        id="first_hire",
+        name="Recruiter",
+        description="",
+        unlocked_tick=3,
+    )
+    tracker.extend((snapshot,))
+
+    assert tracker.evaluate(_base_state()) == ()
+
+
+def test_tracker_validates_unique_identifiers() -> None:
+    definition = AchievementDefinition(
+        id="duplicate",
+        name="Duplicate",
+        description="",
+        condition=lambda state: True,
+    )
+    with pytest.raises(ValueError):
+        AchievementTracker(())
+    tracker = AchievementTracker((definition,))
+    assert tracker.evaluate(_base_state()) != ()

--- a/sim/tests/unit/test_events.py
+++ b/sim/tests/unit/test_events.py
@@ -4,6 +4,7 @@ from typing import List
 
 from ki_dev_tycoon.app import SimulationConfig, run_simulation
 from ki_dev_tycoon.core.events import (
+    AchievementUnlocked,
     EventBus,
     SimulationCompleted,
     SimulationEvent,
@@ -30,11 +31,14 @@ def test_event_bus_collects_simulation_events() -> None:
 
     run_simulation(config, event_bus=bus)
 
-    assert len(received) == 4
+    assert len(received) == 5
     assert received[0] == SimulationStarted(seed=123)
     assert received[1] == TickProcessed(tick=1)
-    assert received[2] == TickProcessed(tick=2)
-    assert received[3] == SimulationCompleted(tick=2)
+    achievement_event = received[2]
+    assert isinstance(achievement_event, AchievementUnlocked)
+    assert achievement_event.achievement.id == "first_hire"
+    assert received[3] == TickProcessed(tick=2)
+    assert received[4] == SimulationCompleted(tick=2)
 
 
 def test_event_bus_unsubscribe_is_noop_when_missing() -> None:

--- a/sim/tests/unit/test_savegame.py
+++ b/sim/tests/unit/test_savegame.py
@@ -7,6 +7,7 @@ from pathlib import Path
 import pytest
 import zstandard as zstd
 
+from ki_dev_tycoon.achievements import AchievementSnapshot
 from ki_dev_tycoon.core.state import (
     GameState,
     ProductState,
@@ -87,3 +88,21 @@ def test_migrate_rejects_unknown_version() -> None:
 
     with pytest.raises(SaveGameError):
         decode_savegame(payload)
+
+
+def test_achievements_survive_roundtrip() -> None:
+    state = _state().add_achievements(
+        (
+            AchievementSnapshot(
+                id="cash_milestone",
+                name="First Funding",
+                description="Reach 50k cash",
+                unlocked_tick=10,
+            ),
+        )
+    )
+    model = GameStateModel.from_state(state)
+
+    assert model.achievements[0].id == "cash_milestone"
+    restored = model.to_state()
+    assert restored.achievements == state.achievements

--- a/sim/tests/unit/test_simulation.py
+++ b/sim/tests/unit/test_simulation.py
@@ -17,6 +17,8 @@ def test_simulation_returns_expected_snapshot() -> None:
     assert result.cash >= 0.0
     assert 0 <= result.reputation <= 100
     assert result.history is None
+    assert result.state["tick"] == 5
+    assert isinstance(result.achievements, list)
 
 
 def test_simulation_history_capture() -> None:
@@ -33,6 +35,7 @@ def test_simulation_history_capture() -> None:
     assert result.history is not None
     assert len(result.history) == config.ticks
     assert all("cash" in row for row in result.history)
+    assert result.state["tick"] == config.ticks
 
 
 def test_simulation_requires_positive_ticks() -> None:

--- a/sim/tests/unit/test_state.py
+++ b/sim/tests/unit/test_state.py
@@ -1,3 +1,4 @@
+from ki_dev_tycoon.achievements import AchievementSnapshot
 from ki_dev_tycoon.core.state import (
     GameState,
     ProductState,
@@ -40,8 +41,31 @@ def test_game_state_reputation_is_clamped() -> None:
 def test_game_state_serialization_roundtrip() -> None:
     frozen_time = FrozenTime(tick=12)
     state = _empty_state().advance_tick(frozen_time)
+    achievement = AchievementSnapshot(
+        id="first_cash",
+        name="Cashflow",
+        description="Reach 10k cash",
+        unlocked_tick=12,
+    )
+    state = state.add_achievements((achievement,))
 
     payload = state.to_dict()
     restored = GameState.from_dict(payload)
 
     assert restored == state
+
+
+def test_add_achievements_is_idempotent() -> None:
+    state = _empty_state()
+    achievement = AchievementSnapshot(
+        id="first_hire",
+        name="Recruiter",
+        description="Hire someone",
+        unlocked_tick=5,
+    )
+
+    updated = state.add_achievements((achievement,))
+    duplicated = updated.add_achievements((achievement,))
+
+    assert updated.achievements == (achievement,)
+    assert duplicated.achievements == (achievement,)


### PR DESCRIPTION
## Summary
- gate runtime imports in the achievements tracker and event bus to prevent circular dependencies
- extend the kernel namespace package so UI helpers (including the new platform module) can be imported reliably
- update the event bus unit test to assert the additional achievement unlock event emitted by the simulation

## Testing
- pytest sim/tests app/tests -q

------
https://chatgpt.com/codex/tasks/task_e_68e551fc390083278ae0843b8e844eb6